### PR TITLE
fix typing of cg.Pieces

### DIFF
--- a/src/anim.ts
+++ b/src/anim.ts
@@ -67,9 +67,9 @@ function computePlan(prevPieces: cg.Pieces, current: State): AnimPlan {
   missings: AnimPiece[] = [],
   news: AnimPiece[] = [],
   prePieces: AnimPieces = {};
-  let curP: cg.Piece, preP: AnimPiece, i: any, vector: cg.NumberPair;
+  let curP: cg.Piece | undefined, preP: AnimPiece | undefined, i: any, vector: cg.NumberPair;
   for (i in prevPieces) {
-    prePieces[i] = makePiece(i as cg.Key, prevPieces[i]);
+    prePieces[i] = makePiece(i as cg.Key, prevPieces[i]!);
   }
   for (const key of util.allKeys) {
     curP = current.pieces[key];

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,7 +121,8 @@ export function configure(state: State, config: Config) {
     const rank = state.movable.color === 'white' ? 1 : 8;
     const kingStartPos = 'e' + rank;
     const dests = state.movable.dests[kingStartPos];
-    if (!dests || state.pieces[kingStartPos].role !== 'king') return;
+    const king = state.pieces[kingStartPos];
+    if (!dests || !king || king.role !== 'king') return;
     state.movable.dests[kingStartPos] = dests.filter(d =>
       !((d === 'a' + rank) && dests.indexOf('c' + rank as cg.Key) !== -1) &&
         !((d === 'h' + rank) && dests.indexOf('g' + rank as cg.Key) !== -1)

--- a/src/fen.ts
+++ b/src/fen.ts
@@ -22,7 +22,8 @@ export function read(fen: cg.FEN): cg.Pieces {
         col = 0;
         break;
       case '~':
-        pieces[pos2key([col, row])].promoted = true;
+        const piece = pieces[pos2key([col, row])];
+        if (piece) piece.promoted = true;
         break;
       default:
         const nb = c.charCodeAt(0);
@@ -41,11 +42,10 @@ export function read(fen: cg.FEN): cg.Pieces {
 }
 
 export function write(pieces: cg.Pieces): cg.FEN {
-  let piece: cg.Piece, letter: string;
   return invRanks.map(y => cg.ranks.map(x => {
-      piece = pieces[pos2key([x, y])];
+      const piece = pieces[pos2key([x, y])];
       if (piece) {
-        letter = letters[piece.role];
+        const letter = letters[piece.role];
         return piece.color === 'white' ? letter.toUpperCase() : letter;
       } else return '1';
     }).join('')

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -47,15 +47,14 @@ function king(color: cg.Color, rookFiles: number[], canCastle: boolean): Mobilit
 }
 
 function rookFilesOf(pieces: cg.Pieces, color: cg.Color) {
-  let piece: cg.Piece;
   return Object.keys(pieces).filter(key => {
-    piece = pieces[key];
+    const piece = pieces[key];
     return piece && piece.color === color && piece.role === 'rook';
   }).map((key: string ) => util.key2pos(key as cg.Key)[0]);
 }
 
 export default function premove(pieces: cg.Pieces, key: cg.Key, canCastle: boolean): cg.Key[] {
-  const piece = pieces[key],
+  const piece = pieces[key]!,
   pos = util.key2pos(key);
   let mobility: Mobility;
   switch (piece.role) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -134,7 +134,7 @@ export default function render(s: State): void {
   // or append new pieces
   for (const j in piecesKeys) {
     k = piecesKeys[j];
-    p = pieces[k];
+    p = pieces[k]!;
     anim = anims[k];
     if (!samePieces[k]) {
       pMvdset = movedPieces[pieceNameOf(p)];

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface Drop {
   key: Key;
 }
 export interface Pieces {
-  [key: string]: Piece;
+  [key: string]: Piece | undefined;
 }
 export interface PiecesDiff {
   [key: string]: Piece | null;


### PR DESCRIPTION
Currently cg.Pieces lies about its type.

```diff
 export interface Pieces {
-  [key: string]: Piece;
+  [key: string]: Piece | undefined;
 }
```

I commented on all cases where I changed behavior. On all other hunks I either used assertions (mostly obvious in context) or managed to convince the compiler that an equivalent version is ok.