### PR TITLE
Raise top left 3d piece over shapes

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -210,8 +210,8 @@ function removeNodes(s: State, nodes: HTMLElement[]): void {
 }
 
 function posZIndex(pos: cg.Pos, asWhite: boolean): string {
-  let z = 2 + pos[1] * 8 + (7 - pos[0]);
-  if (asWhite) z = 67 - z;
+  let z = 3 + pos[1] * 8 + (7 - pos[0]);
+  if (asWhite) z = 69 - z;
   return z + '';
 }
 


### PR DESCRIPTION
Adds 1 to the z-index of all 3d pieces so that the top left piece doesn't get covered by shapes.
Before/after:
<img width="157" alt="Screen Shot 2021-08-26 at 6 07 23 AM" src="https://user-images.githubusercontent.com/7917791/130969290-83525425-655d-4922-a05d-68a38324ab6f.png"><img width="156" alt="Screen Shot 2021-08-26 at 6 05 49 AM" src="https://user-images.githubusercontent.com/7917791/130969422-4665ecc8-4e2f-45c6-b77b-582511884107.png">