### PR TITLE
Targeting issue lila/#10410

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -170,9 +170,9 @@ export function defaults(): HeadlessState {
       shapes: [],
       autoShapes: [],
       brushes: {
-        green: { key: 'g', color: '#15781B', opacity: 1, lineWidth: 10 },
-        red: { key: 'r', color: '#882020', opacity: 1, lineWidth: 10 },
-        blue: { key: 'b', color: '#003088', opacity: 1, lineWidth: 10 },
+        green: { key: 'g', color: '#036408', opacity: 1, lineWidth: 10 },
+        red: { key: 'r', color: '#CF0404', opacity: 1, lineWidth: 10 },
+        blue: { key: 'b', color: '#1851B9', opacity: 1, lineWidth: 10 },
         yellow: { key: 'y', color: '#e68f00', opacity: 1, lineWidth: 10 },
         paleBlue: { key: 'pb', color: '#003088', opacity: 0.4, lineWidth: 15 },
         paleGreen: { key: 'pg', color: '#15781B', opacity: 0.4, lineWidth: 15 },


### PR DESCRIPTION
Issue lila/#10401: Colorblind people cant see the difference between red and green.

Making higher contrast in color brushes so colorblind people can at least see different shades of red and green, and
deuteronopia people (blue-green) now should see different shades too, because of making contrast of green and blue higher.

I didn't change the colors in total, I only varied them to make the contrast higher (and for me they still look good).