### PR TITLE
Only merge plain objects

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -142,11 +142,13 @@ export function configure(state: HeadlessState, config: Config): void {
 
 function deepMerge(base: any, extend: any): void {
   for (const key in extend) {
-    if (isObject(base[key]) && isObject(extend[key])) deepMerge(base[key], extend[key]);
+    if (isPlainObject(base[key]) && isPlainObject(extend[key])) deepMerge(base[key], extend[key]);
     else base[key] = extend[key];
   }
 }
 
-function isObject(o: unknown): boolean {
-  return typeof o === 'object';
+function isPlainObject(o: unknown): boolean {
+  if (typeof o !== 'object' || o === null) return false;
+  const proto = Object.getPrototypeOf(o);
+  return proto === Object.prototype || proto === null;
 }


### PR DESCRIPTION
When merging in a new config, it shouldn't try to deep merge the HTMLElement `addDimensionsCssVarsTo` (which will throw when trying to assign read-only properties).

ig could just check specifically for HTMLElements or that key but seems better to future proof it and check that it's a reasonably proper plain object.