### PR TITLE
added moduleResolution to tsconfig so it can install dependencies successfully

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitThis": true,
     "noImplicitReturns": true,
     "module": "esnext",
+    "moduleResolution": "node",
     "target": "ES2017",
     "lib": ["DOM", "ES2017"]
   }


### PR DESCRIPTION
Before making this change, I was getting the following error:

```
yarn install v1.22.17
...
$ tsc --outDir . --sourceMap --declaration
../../../../../../node_modules/@types/trusted-types/index.d.ts:10:22 - error TS2792: Cannot find module './lib'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?

10 import * as lib from './lib';
                        ~~~~~~~


Found 1 error in ../../../../../../node_modules/@types/trusted-types/index.d.ts:10

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Afterwards, I'm able to run `yarn install` without any problems.