### PR TITLE
Improve brush type

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -2,11 +2,12 @@ import { State } from './state.js';
 import { unselect, cancelMove, getKeyAtDomPos, getSnappedKeyAtDomPos, whitePov } from './board.js';
 import { eventPosition, isRightButton } from './util.js';
 import * as cg from './types.js';
+import { BrushColor } from './types.js';
 
 export interface DrawShape {
   orig: cg.Key;
   dest?: cg.Key;
-  brush?: string;
+  brush: BrushColor;
   modifiers?: DrawModifiers;
   piece?: DrawShapePiece;
   customSvg?: string;
@@ -138,7 +139,7 @@ function addShape(drawable: Drawable, cur: DrawCurrent): void {
     drawable.shapes.push({
       orig: cur.orig,
       dest: cur.dest,
-      brush: cur.brush,
+      brush: cur.brush as BrushColor,
     });
   onChange(drawable);
 }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -2,12 +2,11 @@ import { State } from './state.js';
 import { unselect, cancelMove, getKeyAtDomPos, getSnappedKeyAtDomPos, whitePov } from './board.js';
 import { eventPosition, isRightButton } from './util.js';
 import * as cg from './types.js';
-import { BrushColor } from './types.js';
 
 export interface DrawShape {
   orig: cg.Key;
   dest?: cg.Key;
-  brush: BrushColor;
+  brush: cg.BrushColor;
   modifiers?: DrawModifiers;
   piece?: DrawShapePiece;
   customSvg?: string;
@@ -139,7 +138,7 @@ function addShape(drawable: Drawable, cur: DrawCurrent): void {
     drawable.shapes.push({
       orig: cur.orig,
       dest: cur.dest,
-      brush: cur.brush as BrushColor,
+      brush: cur.brush as cg.BrushColor,
     });
   onChange(drawable);
 }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -51,11 +51,11 @@ export interface DrawCurrent {
   dest?: cg.Key; // shape dest, or undefined for circle
   mouseSq?: cg.Key; // square being moused over
   pos: cg.NumberPair; // relative current position
-  brush: string; // brush name for shape
+  brush: cg.BrushColor; // brush name for shape
   snapToValidMove: boolean; // whether to snap to valid piece moves
 }
 
-const brushes = ['green', 'red', 'blue', 'yellow'];
+const brushes: Partial<cg.BrushColor>[] = ['green', 'red', 'blue', 'yellow'];
 
 export function start(state: State, e: cg.MouchEvent): void {
   // support one finger touch only
@@ -124,7 +124,7 @@ export function clear(state: State): void {
   }
 }
 
-function eventBrush(e: cg.MouchEvent): string {
+function eventBrush(e: cg.MouchEvent): cg.BrushColor {
   const modA = (e.shiftKey || e.ctrlKey) && isRightButton(e);
   const modB = e.altKey || e.metaKey || e.getModifierState?.('AltGraph');
   return brushes[(modA ? 1 : 0) + (modB ? 2 : 0)];
@@ -138,7 +138,7 @@ function addShape(drawable: Drawable, cur: DrawCurrent): void {
     drawable.shapes.push({
       orig: cur.orig,
       dest: cur.dest,
-      brush: cur.brush as cg.BrushColor,
+      brush: cur.brush,
     });
   onChange(drawable);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,3 +103,5 @@ export const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 export const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'] as const;
 
 export type RanksPosition = 'left' | 'right';
+
+export type BrushColor = 'red' | 'green' | 'blue' | 'paleBlue' | 'yellow' | 'paleGreen' | 'paleRed' | 'paleGrey';


### PR DESCRIPTION
brush in DrawShape is currently typed as string | undefined.
Passing undefined to brush crashes when using setShapes(): Uncaught TypeError: brush is undefined (svg.ts:87)
So it should be atleast string type.

I also added the available colors to the brush property, from state.ts. Because if you pass black as a string it just crashes. It would be nice if the available colors are in the type.