### PR TITLE
allow to define pre configured shapes on a board with supplied fen

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -107,7 +107,6 @@ export function configure(state: HeadlessState, config: Config): void {
   // if a fen was provided, replace the pieces
   if (config.fen) {
     state.pieces = fenRead(config.fen);
-    state.drawable.shapes = [];
   }
 
   // apply config values that could be undefined yet meaningful


### PR DESCRIPTION
When configuring a new board with predefined shapes in `config.drawable.shapes` while also supplying an initial FEN, it ignores the given shapes