### PR TITLE
Added exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "module": "chessground.js",
   "typings": "chessground.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*.js"
+  },
   "dependencies": {},
   "devDependencies": {
     "@rollup/plugin-typescript": "^8",


### PR DESCRIPTION
This fixes `[DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json`.