### PR TITLE
Fixed package.json exports bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "module": "chessground.js",
   "typings": "chessground.d.ts",
   "exports": {
-    ".": "./index.js",
-    "./*": "./*.js"
+    ".": "./chessground.js",
+    "./*": "./*"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Sorry about this, but the previous pull request ([#258](https://github.com/lichess-org/chessground/pull/258)) had a bug in which you could not import the css stylesheets. This one should fix it.