### PR TITLE
Fix bug where pieces weren't horizontally aligned properly when zoomed on browser

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -185,9 +185,8 @@ export function renderResized(s: State): void {
 export function updateBounds(s: State): void {
   const bounds = s.dom.elements.wrap.getBoundingClientRect();
   const container = s.dom.elements.container;
-  const ratio = bounds.height / bounds.width;
-  const width = (Math.floor((bounds.width * window.devicePixelRatio) / 8) * 8) / window.devicePixelRatio;
-  const height = width * ratio;
+  const width = bounds.width;
+  const height = bounds.height;
   container.style.width = width + 'px';
   container.style.height = height + 'px';
   s.dom.bounds.clear();


### PR DESCRIPTION
The updateBounds function was truncating the fractional part of the board's width and height. There is no reason to do this. Fractional pixel widths/heights are a legit thing.