### PR TITLE
Add optional config setting to trust all input

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export interface Config {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll?: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   // pieceKey: boolean; // add a data-key attribute to piece elements
-  trustAllEvents?: boolean,
+  trustAllEvents?: boolean, // disable checking for human only input (e.isTrusted)
   highlight?: {
     lastMove?: boolean; // add last-move class to squares
     check?: boolean; // add check class to squares

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface Config {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll?: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   // pieceKey: boolean; // add a data-key attribute to piece elements
+  trustAllEvents?: boolean,
   highlight?: {
     lastMove?: boolean; // add last-move class to squares
     check?: boolean; // add check class to squares

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -20,7 +20,8 @@ export interface DragCurrent {
 }
 
 export function start(s: State, e: cg.MouchEvent): void {
-  if (!e.isTrusted || (e.button !== undefined && e.button !== 0)) return; // only touch or left click
+  if (!(s.trustAllEvents || e.isTrusted)) return; // only trust when trustAllEvents is enabled
+  if (e.button !== undefined && e.button !== 0) return; // only touch or left click
   if (e.touches && e.touches.length > 1) return; // support one finger touch only
   const bounds = s.dom.bounds(),
     position = util.eventPosition(e)!,

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,7 +21,7 @@ export interface HeadlessState {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   pieceKey: boolean; // add a data-key attribute to piece elements
-  trustAllEvents?: boolean,
+  trustAllEvents?: boolean, // disable checking for human only input (e.isTrusted)
   highlight: {
     lastMove: boolean; // add last-move class to squares
     check: boolean; // add check class to squares

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,6 +21,7 @@ export interface HeadlessState {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   pieceKey: boolean; // add a data-key attribute to piece elements
+  trustAllEvents?: boolean,
   highlight: {
     lastMove: boolean; // add last-move class to squares
     check: boolean; // add check class to squares
@@ -117,6 +118,7 @@ export function defaults(): HeadlessState {
     addPieceZIndex: false,
     blockTouchScroll: false,
     pieceKey: false,
+    trustAllEvents: false,
     highlight: {
       lastMove: true,
       check: true,


### PR DESCRIPTION
Add `trustAllEvents` optional property that when set to true will allow non trusted events.

This is useful for e2e tests and automating software.