### PR TITLE
Update Prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,5 @@ jobs:
       - uses: github/codeql-action/analyze@v2
       - run: pnpm install
       - run: pnpm run lint
+      - run: pnpm run check-format
       - run: pnpm run dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pnpm-store/
 node_modules/
 dist/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 dist/
 
+pnpm-lock.yaml
+
 *.js
 *.d.ts
 *.js.map

--- a/demo.html
+++ b/demo.html
@@ -1,32 +1,32 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Chessground Demo</title>
 
-    <link rel="stylesheet" type="text/css" href="assets/chessground.base.css">
-    <link rel="stylesheet" type="text/css" href="assets/chessground.brown.css">
-    <link rel="stylesheet" type="text/css" href="assets/chessground.cburnett.css">
+    <link rel="stylesheet" type="text/css" href="assets/chessground.base.css" />
+    <link rel="stylesheet" type="text/css" href="assets/chessground.brown.css" />
+    <link rel="stylesheet" type="text/css" href="assets/chessground.cburnett.css" />
     <style>
-        #chessground {
-            width: 500px;
-            height: 500px;
-        }
+      #chessground {
+        width: 500px;
+        height: 500px;
+      }
 
-        cg-board {
-            background-color: #bfcfdd;
-        }
+      cg-board {
+        background-color: #bfcfdd;
+      }
     </style>
 
     <script type="module">
-        import { Chessground } from './chessground.js';
+      import { Chessground } from './chessground.js';
 
-        const config = {};
-        const ground = Chessground(document.getElementById('chessground'), config);
+      const config = {};
+      const ground = Chessground(document.getElementById('chessground'), config);
     </script>
-</head>
-<body>
+  </head>
+  <body>
     <div id="chessground"></div>
-</body>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
     "eslint": "^8.42.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "rollup": "^2.79.1",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ devDependencies:
     specifier: ^8.42.0
     version: 8.42.0
   prettier:
-    specifier: ^2.8.8
-    version: 2.8.8
+    specifier: ^3.0.0
+    version: 3.0.0
   rollup:
     specifier: ^2.79.1
     version: 2.79.1
@@ -1011,9 +1011,9 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.0.0:
+    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 

--- a/src/anim.ts
+++ b/src/anim.ts
@@ -74,7 +74,7 @@ function computePlan(prevPieces: cg.Pieces, current: State): AnimPlan {
   for (const newP of news) {
     preP = closer(
       newP,
-      missings.filter(p => util.samePiece(newP.piece, p.piece))
+      missings.filter(p => util.samePiece(newP.piece, p.piece)),
     );
     if (preP) {
       vector = [preP.pos[0] - newP.pos[0], preP.pos[1] - newP.pos[1]];

--- a/src/board.ts
+++ b/src/board.ts
@@ -204,7 +204,7 @@ export function setSelected(state: HeadlessState, key: cg.Key): void {
   state.selected = key;
   if (isPremovable(state, key)) {
     // calculate chess premoves if custom premoves are not passed
-    if(!state.premovable.customDests) {
+    if (!state.premovable.customDests) {
       state.premovable.dests = premove(state.pieces, key, state.premovable.castle);
     }
   } else state.premovable.dests = undefined;
@@ -242,7 +242,8 @@ function isPremovable(state: HeadlessState, orig: cg.Key): boolean {
 }
 
 function canPremove(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
-  const validPremoves: cg.Key[] = state.premovable.customDests?.get(orig) ?? premove(state.pieces, orig, state.premovable.castle);
+  const validPremoves: cg.Key[] =
+    state.premovable.customDests?.get(orig) ?? premove(state.pieces, orig, state.premovable.castle);
   return orig !== dest && isPremovable(state, orig) && validPremoves.includes(dest);
 }
 
@@ -332,17 +333,17 @@ export function getSnappedKeyAtDomPos(
   orig: cg.Key,
   pos: cg.NumberPair,
   asWhite: boolean,
-  bounds: DOMRectReadOnly
+  bounds: DOMRectReadOnly,
 ): cg.Key | undefined {
   const origPos = key2pos(orig);
   const validSnapPos = allPos.filter(
-    pos2 => queen(origPos[0], origPos[1], pos2[0], pos2[1]) || knight(origPos[0], origPos[1], pos2[0], pos2[1])
+    pos2 => queen(origPos[0], origPos[1], pos2[0], pos2[1]) || knight(origPos[0], origPos[1], pos2[0], pos2[1]),
   );
   const validSnapCenters = validSnapPos.map(pos2 => computeSquareCenter(pos2key(pos2), asWhite, bounds));
   const validSnapDistances = validSnapCenters.map(pos2 => distanceSq(pos, pos2));
   const [, closestSnapIndex] = validSnapDistances.reduce(
     (a, b, index) => (a[0] < b ? a : [b, index]),
-    [validSnapDistances[0], 0]
+    [validSnapDistances[0], 0],
   );
   return pos2key(validSnapPos[closestSnapIndex]);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export interface Config {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll?: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   // pieceKey: boolean; // add a data-key attribute to piece elements
-  trustAllEvents?: boolean, // disable checking for human only input (e.isTrusted)
+  trustAllEvents?: boolean; // disable checking for human only input (e.isTrusted)
   highlight?: {
     lastMove?: boolean; // add last-move class to squares
     check?: boolean; // add check class to squares
@@ -137,8 +137,8 @@ export function configure(state: HeadlessState, config: Config): void {
       dests.filter(
         d =>
           !(d === 'a' + rank && dests.includes(('c' + rank) as cg.Key)) &&
-          !(d === 'h' + rank && dests.includes(('g' + rank) as cg.Key))
-      )
+          !(d === 'h' + rank && dests.includes(('g' + rank) as cg.Key)),
+      ),
     );
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -57,7 +57,7 @@ function unbindable(
   el: EventTarget,
   eventName: string,
   callback: EventListener,
-  options?: AddEventListenerOptions
+  options?: AddEventListenerOptions,
 ): cg.Unbind {
   el.addEventListener(eventName, callback, options);
   return () => el.removeEventListener(eventName, callback, options);

--- a/src/fen.ts
+++ b/src/fen.ts
@@ -71,7 +71,7 @@ export function write(pieces: cg.Pieces): cg.FEN {
             return p;
           } else return '1';
         })
-        .join('')
+        .join(''),
     )
     .join('/')
     .replace(/1{2,}/g, s => s.length.toString());

--- a/src/state.ts
+++ b/src/state.ts
@@ -21,7 +21,7 @@ export interface HeadlessState {
   addDimensionsCssVarsTo?: HTMLElement; // add --cg-width and --cg-height CSS vars containing the board's dimensions to this element
   blockTouchScroll: boolean; // block scrolling via touch dragging on the board, e.g. for coordinate training
   pieceKey: boolean; // add a data-key attribute to piece elements
-  trustAllEvents?: boolean, // disable checking for human only input (e.isTrusted)
+  trustAllEvents?: boolean; // disable checking for human only input (e.isTrusted)
   highlight: {
     lastMove: boolean; // add last-move class to squares
     check: boolean; // add check class to squares

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -67,12 +67,12 @@ export function renderSvg(state: State, svg: SVGElement, customSvg: SVGElement):
   syncShapes(
     shapes.filter(s => !s.shape.customSvg),
     shapesEl,
-    shape => renderShape(state, shape, d.brushes, arrowDests, bounds)
+    shape => renderShape(state, shape, d.brushes, arrowDests, bounds),
   );
   syncShapes(
     shapes.filter(s => s.shape.customSvg),
     customSvgsEl,
-    shape => renderShape(state, shape, d.brushes, arrowDests, bounds)
+    shape => renderShape(state, shape, d.brushes, arrowDests, bounds),
   );
 }
 
@@ -103,7 +103,7 @@ function shapeHash(
   { orig, dest, brush, piece, modifiers, customSvg }: DrawShape,
   arrowDests: ArrowDests,
   current: boolean,
-  bounds: DOMRectReadOnly
+  bounds: DOMRectReadOnly,
 ): Hash {
   return [
     bounds.width,
@@ -143,7 +143,7 @@ function renderShape(
   { shape, current, hash }: SyncableShape,
   brushes: DrawBrushes,
   arrowDests: ArrowDests,
-  bounds: DOMRectReadOnly
+  bounds: DOMRectReadOnly,
 ): SVGElement {
   let el: SVGElement;
   const orig = orient(key2pos(shape.orig), state.orientation);
@@ -161,7 +161,7 @@ function renderShape(
         current,
         (arrowDests.get(shape.dest) || 0) > 1,
         bounds,
-        shape.modifiers?.hilite
+        shape.modifiers?.hilite,
       );
     } else el = renderCircle(brushes[shape.brush], orig, current, bounds);
   }
@@ -205,7 +205,7 @@ function renderArrow(
   current: boolean,
   shorten: boolean,
   bounds: DOMRectReadOnly,
-  hilited = false
+  hilited = false,
 ): SVGElement {
   function renderInner(isHilite: boolean) {
     const m = arrowMargin(shorten && !current),
@@ -246,7 +246,7 @@ function renderMarker(brush: DrawBrush): SVGElement {
     setAttributes(createElement('path'), {
       d: 'M0,0 V4 L3,2 Z',
       fill: brush.color,
-    })
+    }),
   );
   marker.setAttribute('cgKey', brush.key);
   return marker;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -12,7 +12,7 @@ export type Hash = string;
 export function syncShapes(
   shapes: SyncableShape[],
   root: HTMLElement | SVGElement,
-  renderShape: (shape: SyncableShape) => HTMLElement | SVGElement
+  renderShape: (shape: SyncableShape) => HTMLElement | SVGElement,
 ): void {
   const hashesInDom = new Map(), // by hash
     toRemove: SVGElement[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-export type Color = typeof colors[number];
+export type Color = (typeof colors)[number];
 export type Role = 'king' | 'queen' | 'rook' | 'bishop' | 'knight' | 'pawn';
-export type File = typeof files[number];
-export type Rank = typeof ranks[number];
+export type File = (typeof files)[number];
+export type Rank = (typeof ranks)[number];
 export type Key = 'a0' | `${File}${Rank}`;
 export type FEN = string;
 export type Pos = [number, number];

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,8 +58,10 @@ export const samePiece = (p1: cg.Piece, p2: cg.Piece): boolean => p1.role === p2
 
 export const posToTranslate =
   (bounds: DOMRectReadOnly): ((pos: cg.Pos, asWhite: boolean) => cg.NumberPair) =>
-  (pos, asWhite) =>
-    [((asWhite ? pos[0] : 7 - pos[0]) * bounds.width) / 8, ((asWhite ? 7 - pos[1] : pos[1]) * bounds.height) / 8];
+  (pos, asWhite) => [
+    ((asWhite ? pos[0] : 7 - pos[0]) * bounds.width) / 8,
+    ((asWhite ? 7 - pos[1] : pos[1]) * bounds.height) / 8,
+  ];
 
 export const translate = (el: HTMLElement, pos: cg.NumberPair): void => {
   el.style.transform = `translate(${pos[0]}px,${pos[1]}px)`;


### PR DESCRIPTION
- Update prettier to 3.0.0
- Add formatting check to Github action
- run the formatter

With 3.0.0, the default config value for `trailingComma` is now `all`, so we can either go with that or change it in [.prettierrc.json](https://github.com/lichess-org/chessground/blob/master/.prettierrc.json)