### PR TITLE
Fix path to chessground.js in demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -20,7 +20,7 @@
     </style>
 
     <script type="module">
-      import { Chessground } from './chessground.js';
+      import { Chessground } from './dist/chessground.js';
 
       const config = {};
       const ground = Chessground(document.getElementById('chessground'), config);


### PR DESCRIPTION
Build destination changed recently in https://github.com/lichess-org/chessground/commit/83562102c039ec323a4b59c3b35cbdae371c85fb