### PR TITLE
Crazyhouse drops by click-click

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -23,7 +23,7 @@
         height: 500px;
       }
 
-      .selected-pocket {
+      .selected-to-drop {
         background-color: rgba(20, 85, 30, 0.5);
       }
 

--- a/demo.html
+++ b/demo.html
@@ -23,6 +23,15 @@
         height: 500px;
       }
 
+      .selected-pocket {
+        background-color: rgba(20, 85, 30, 0.5);
+      }
+
+      #pocket {
+        display: flex;
+        flex-direction: row;
+      }
+
       cg-board {
         background-color: #bfcfdd;
       }
@@ -30,6 +39,7 @@
 
     <script type="module">
       import { Chessground } from './dist/chessground.js';
+      import { setDropMode } from './dist/drop.js';
 
       Chessground(document.getElementById('board-1'), {});
       Chessground(document.getElementById('board-2'), {
@@ -83,6 +93,20 @@
           ],
         },
       });
+      const dropBoard = Chessground(document.getElementById('board-4'), {
+        draggable: { enabled: true },
+        selectable: { enabled: true },
+      });
+      window.cgState = dropBoard.state;
+      ['white', 'black'].forEach(color => {
+        ['pawn', 'knight', 'bishop'].forEach(role => {
+          const el = document.getElementById(`drop-${color}-${role}`);
+          el.addEventListener('mousedown', event => {
+            event.preventDefault();
+            dropBoard.dragNewPiece({ role, color }, event, false);
+          });
+        });
+      });
     </script>
   </head>
   <body>
@@ -97,6 +121,30 @@
     <div>
       board with fixed arrows + labels
       <div class="chessground" id="board-3"></div>
+    </div>
+    <div>
+      board with droppable pieces
+      <div class="chessground" id="board-4"></div>
+      <div id="pocket">
+        <div id="drop-white-pawn" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="white pawn"></piece>
+        </div>
+        <div id="drop-white-knight" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="white knight"></piece>
+        </div>
+        <div id="drop-white-bishop" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="white bishop"></piece>
+        </div>
+        <div id="drop-black-pawn" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="black pawn"></piece>
+        </div>
+        <div id="drop-black-knight" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="black knight"></piece>
+        </div>
+        <div id="drop-black-bishop" class="cg-wrap" style="width: 50px; height: 50px">
+          <piece style="width: 50px; height: 50px" class="black bishop"></piece>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/src/board.ts
+++ b/src/board.ts
@@ -194,8 +194,7 @@ export function selectNewPieceToDrop(
 ): void {
   if (state.selected || state.selectedToDrop) unselect(state);
   callUserFunction(state.events.select, 'a0');
-  (originTarget as HTMLElement).classList.add('selected-pocket');
-
+  (originTarget as HTMLElement).classList.add('selected-to-drop');
   state.selectedToDrop = { piece, originTarget };
 }
 
@@ -238,7 +237,7 @@ export function setSelected(state: HeadlessState, key: cg.Key): void {
 
 export function unselect(state: HeadlessState): void {
   if (state.selectedToDrop) {
-    (state.selectedToDrop.originTarget as HTMLElement).classList.remove('selected-pocket');
+    (state.selectedToDrop.originTarget as HTMLElement).classList.remove('selected-to-drop');
     state.selectedToDrop = undefined;
   }
   state.selected = undefined;

--- a/src/board.ts
+++ b/src/board.ts
@@ -164,8 +164,9 @@ export function userMove(state: HeadlessState, orig: cg.Key, dest: cg.Key): bool
   return false;
 }
 
-export function dropNewPiece(state: HeadlessState, orig: cg.Key, dest: cg.Key, force?: boolean): void {
+export function dropNewPiece(state: HeadlessState, orig: cg.Key, dest: cg.Key, force?: boolean): boolean {
   const piece = state.pieces.get(orig);
+  let dropped = false;
   if (piece && (canDrop(state, orig, dest) || force)) {
     state.pieces.delete(orig);
     baseNewPiece(state, piece, dest, force);
@@ -173,6 +174,8 @@ export function dropNewPiece(state: HeadlessState, orig: cg.Key, dest: cg.Key, f
       premove: false,
       predrop: false,
     });
+
+    dropped = true;
   } else if (piece && canPredrop(state, orig, dest)) {
     setPredrop(state, piece.role, dest);
   } else {
@@ -181,6 +184,19 @@ export function dropNewPiece(state: HeadlessState, orig: cg.Key, dest: cg.Key, f
   }
   state.pieces.delete(orig);
   unselect(state);
+  return dropped;
+}
+
+export function selectNewPieceToDrop(
+  state: HeadlessState,
+  piece: cg.Piece,
+  originTarget: EventTarget | null,
+): void {
+  if (state.selected || state.selectedToDrop) unselect(state);
+  callUserFunction(state.events.select, 'a0');
+  (originTarget as HTMLElement).classList.add('selected-pocket');
+
+  state.selectedToDrop = { piece, originTarget };
 }
 
 export function selectSquare(state: HeadlessState, key: cg.Key, force?: boolean): void {
@@ -196,6 +212,10 @@ export function selectSquare(state: HeadlessState, key: cg.Key, force?: boolean)
         return;
       }
     }
+  }
+  if (state.selectedToDrop) {
+    state.pieces.set('a0', state.selectedToDrop.piece);
+    if (dropNewPiece(state, 'a0', key)) return;
   }
   if (
     (state.selectable.enabled || state.draggable.enabled) &&
@@ -217,6 +237,10 @@ export function setSelected(state: HeadlessState, key: cg.Key): void {
 }
 
 export function unselect(state: HeadlessState): void {
+  if (state.selectedToDrop) {
+    (state.selectedToDrop.originTarget as HTMLElement).classList.remove('selected-pocket');
+    state.selectedToDrop = undefined;
+  }
   state.selected = undefined;
   state.premovable.dests = undefined;
   state.hold.cancel();

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,6 +12,10 @@ export interface HeadlessState {
   check?: cg.Key; // square currently in check "a2"
   lastMove?: cg.Key[]; // squares part of the last move ["c3"; "c4"]
   selected?: cg.Key; // square currently selected "a1"
+  selectedToDrop?: { // piece currently selected to drop
+    piece: cg.Piece,
+    originTarget: EventTarget | null,
+  }
   coordinates: boolean; // include coords attributes
   ranksPosition: cg.RanksPosition; // position ranks on either side. left | right
   autoCastle: boolean; // immediately complete the castle by moving the rook after king move


### PR DESCRIPTION
fixes lichess-org/lila#12866
This change is dependant on this follow-up PR on lila that adds a CSS class for the selected piece within the pocket:
[https://github.com/lichess-org/lila/pull/14052]()

This change makes it so that when you click an external piece and try to drag it onto the board and drop it (such as in the crazyhouse variant), you have the option to click and select (previously only drag and drop was possible).

I implemented this by making the dragNewPiece function in drag.ts also select the new piece.
Then if the drag ends on the same element where it started, we count that as a click and select that piece.
When the user clicks an empty space on the board, we drop the selected piece onto that square.

I also added a board to demo.html that allows you to drop pieces on it.

I also made it respect state.selectable.enabled and state.draggable.enabled for external pieces the same as pieces on the board because previously dragging was the only way to drop pieces in crazyhouse.
With this change, we should respect the user's preferences for whether they allow dragging, clicking, or both.