### PR TITLE
export same width & height variables as aliases with three hyphens

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -191,7 +191,9 @@ export function updateBounds(s: State): void {
   s.dom.bounds.clear();
 
   s.addDimensionsCssVarsTo?.style.setProperty('--cg-width', width + 'px');
+  s.addDimensionsCssVarsTo?.style.setProperty('---cg-width', width + 'px');
   s.addDimensionsCssVarsTo?.style.setProperty('--cg-height', height + 'px');
+  s.addDimensionsCssVarsTo?.style.setProperty('---cg-height', height + 'px');
 }
 
 const isPieceNode = (el: cg.PieceNode | cg.SquareNode): el is cg.PieceNode => el.tagName === 'PIECE';


### PR DESCRIPTION
Non-color css variables in the lila asset-hash-caching branch are (currently) preceded with three rather than two hyphens to sort them above all the colors in inspector.

Right now the two chessground vars are the only laggards and it would be nice if one day we could bump them up above the colors as well.