### PR TITLE
Improve CSS for coordinate text placement and color

### DIFF
--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -173,7 +173,7 @@ piece.fading {
   transform: translateY(39%);
 }
 
-coords.squares {
+.cg-wrap coords.squares {
   bottom: 0;
   left: 0;
   text-transform: uppercase;
@@ -181,44 +181,44 @@ coords.squares {
   flex-flow: column-reverse;
   height: 100%;
   width: 12.5%;
+}
 
-  &.black {
-    flex-flow: column;
-  }
+.cg-wrap coords.squares.black {
+  flex-flow: column;
+}
 
-  &.left {
-    text-align: left;
-  }
+.cg-wrap coords.squares.left {
+  text-align: left;
+}
 
-  coord {
-    padding: 6% 4%;
-  }
+.cg-wrap coords.squares coord {
+  padding: 6% 4%;
+}
 
-  &.rank2 {
-    transform: translateX(100%);
-  }
+.cg-wrap coords.squares.rank2 {
+  transform: translateX(100%);
+}
 
-  &.rank3 {
-    transform: translateX(200%);
-  }
+.cg-wrap coords.squares.rank3 {
+  transform: translateX(200%);
+}
 
-  &.rank4 {
-    transform: translateX(300%);
-  }
+.cg-wrap coords.squares.rank4 {
+  transform: translateX(300%);
+}
 
-  &.rank5 {
-    transform: translateX(400%);
-  }
+.cg-wrap coords.squares.rank5 {
+  transform: translateX(400%);
+}
 
-  &.rank6 {
-    transform: translateX(500%);
-  }
+.cg-wrap coords.squares.rank6 {
+  transform: translateX(500%);
+}
 
-  &.rank7 {
-    transform: translateX(600%);
-  }
+.cg-wrap coords.squares.rank7 {
+  transform: translateX(600%);
+}
 
-  &.rank8 {
-    transform: translateX(700%);
-  }
+.cg-wrap coords.squares.rank8 {
+  transform: translateX(700%);
 }

--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -173,7 +173,7 @@ piece.fading {
   transform: translateY(39%);
 }
 
-.cg-wrap coords.squares {
+coords.squares {
   bottom: 0;
   left: 0;
   text-transform: uppercase;
@@ -181,44 +181,44 @@ piece.fading {
   flex-flow: column-reverse;
   height: 100%;
   width: 12.5%;
-}
 
-.cg-wrap coords.squares.black {
-  flex-flow: column;
-}
+  &.black {
+    flex-flow: column;
+  }
 
-.cg-wrap coords.squares.left {
-  text-align: left;
-}
+  &.left {
+    text-align: left;
+  }
 
-.cg-wrap coords.squares coord {
-  padding: 6% 4%;
-}
+  coord {
+    padding: 6% 4%;
+  }
 
-.cg-wrap coords.squares.rank2 {
-  transform: translateX(100%);
-}
+  &.rank2 {
+    transform: translateX(100%);
+  }
 
-.cg-wrap coords.squares.rank3 {
-  transform: translateX(200%);
-}
+  &.rank3 {
+    transform: translateX(200%);
+  }
 
-.cg-wrap coords.squares.rank4 {
-  transform: translateX(300%);
-}
+  &.rank4 {
+    transform: translateX(300%);
+  }
 
-.cg-wrap coords.squares.rank5 {
-  transform: translateX(400%);
-}
+  &.rank5 {
+    transform: translateX(400%);
+  }
 
-.cg-wrap coords.squares.rank6 {
-  transform: translateX(500%);
-}
+  &.rank6 {
+    transform: translateX(500%);
+  }
 
-.cg-wrap coords.squares.rank7 {
-  transform: translateX(600%);
-}
+  &.rank7 {
+    transform: translateX(600%);
+  }
 
-.cg-wrap coords.squares.rank8 {
-  transform: translateX(700%);
+  &.rank8 {
+    transform: translateX(700%);
+  }
 }

--- a/assets/chessground.brown.css
+++ b/assets/chessground.brown.css
@@ -43,16 +43,20 @@ cg-board square.current-premove {
 }
 
 /** Alternating colors in rank/file/square labels */
-.cg-wrap coords:nth-child(odd) coord:nth-child(even),
-.cg-wrap coords.squares:nth-child(even) coord:nth-child(odd),
-.cg-wrap.orientation-black coords.files:nth-child(even) coord:nth-child(odd),
-.cg-wrap coords.files:nth-child(even) coord:nth-child(even) {
+.cg-wrap.orientation-white coords.ranks coord:nth-child(odd),
+.cg-wrap.orientation-white coords.files coord:nth-child(even),
+.cg-wrap.orientation-black coords.ranks coord:nth-child(even),
+.cg-wrap.orientation-black coords.files coord:nth-child(odd),
+.cg-wrap coords.squares:nth-of-type(odd) coord:nth-child(even),
+.cg-wrap coords.squares:nth-of-type(even) coord:nth-child(odd) {
   color: rgba(72, 72, 72, 0.8);
 }
 
-.cg-wrap coords:nth-child(odd) coord:nth-child(odd),
-.cg-wrap coords.squares:nth-child(even) coord:nth-child(even),
-.cg-wrap.orientation-black coords.files:nth-child(even) coord:nth-child(even),
-.cg-wrap coords.files:nth-child(even) coord:nth-child(odd) {
+.cg-wrap.orientation-white coords.ranks coord:nth-child(even),
+.cg-wrap.orientation-white coords.files coord:nth-child(odd),
+.cg-wrap.orientation-black coords.ranks coord:nth-child(odd),
+.cg-wrap.orientation-black coords.files coord:nth-child(even),
+.cg-wrap coords.squares:nth-of-type(odd) coord:nth-child(odd),
+.cg-wrap coords.squares:nth-of-type(even) coord:nth-child(even) {
   color: rgba(255, 255, 255, 0.8);
 }

--- a/assets/chessground.brown.css
+++ b/assets/chessground.brown.css
@@ -43,20 +43,20 @@ cg-board square.current-premove {
 }
 
 /** Alternating colors in rank/file/square labels */
-.cg-wrap.orientation-white coords.ranks coord:nth-child(odd),
-.cg-wrap.orientation-white coords.files coord:nth-child(even),
-.cg-wrap.orientation-black coords.ranks coord:nth-child(even),
-.cg-wrap.orientation-black coords.files coord:nth-child(odd),
-.cg-wrap coords.squares:nth-of-type(odd) coord:nth-child(even),
-.cg-wrap coords.squares:nth-of-type(even) coord:nth-child(odd) {
+.orientation-white .ranks :nth-child(odd),
+.orientation-white .files :nth-child(even),
+.orientation-black .ranks :nth-child(even),
+.orientation-black .files :nth-child(odd),
+coords.squares:nth-of-type(odd) :nth-child(even),
+coords.squares:nth-of-type(even) :nth-child(odd) {
   color: rgba(72, 72, 72, 0.8);
 }
 
-.cg-wrap.orientation-white coords.ranks coord:nth-child(even),
-.cg-wrap.orientation-white coords.files coord:nth-child(odd),
-.cg-wrap.orientation-black coords.ranks coord:nth-child(odd),
-.cg-wrap.orientation-black coords.files coord:nth-child(even),
-.cg-wrap coords.squares:nth-of-type(odd) coord:nth-child(odd),
-.cg-wrap coords.squares:nth-of-type(even) coord:nth-child(even) {
+.orientation-white .ranks :nth-child(even),
+.orientation-white .files :nth-child(odd),
+.orientation-black .ranks :nth-child(odd),
+.orientation-black .files :nth-child(even),
+coords.squares:nth-of-type(odd) :nth-child(odd),
+coords.squares:nth-of-type(even) :nth-child(even) {
   color: rgba(255, 255, 255, 0.8);
 }


### PR DESCRIPTION
to match changes in https://github.com/lichess-org/lila/pull/15221

edit: specifically the changes in the [_coords-colors](https://github.com/lichess-org/lila/pull/15221/files#diff-ed7faa660ac62c087a3b311b0b04f66bd626c3c88d30c4f227760db77ca5bcab) file