### PR TITLE
fix: `snapToValidMove` update issue

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -87,9 +87,7 @@ export function processDraw(state: State): void {
     const cur = state.drawable.current;
     if (cur) {
       const keyAtDomPos = getKeyAtDomPos(cur.pos, whitePov(state), state.dom.bounds());
-      if (!keyAtDomPos) {
-        cur.snapToValidMove = false;
-      }
+      cur.snapToValidMove = !!keyAtDomPos;
       const mouseSq = cur.snapToValidMove
         ? getSnappedKeyAtDomPos(cur.orig, cur.pos, whitePov(state), state.dom.bounds())
         : keyAtDomPos;


### PR DESCRIPTION
Closes #307 

This PR fixes the `cur.snapToValidMove` update when the pointer returns after being outside of the chessboard.