### PR TITLE
Add Link to Updated Svelte Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const ground = Chessground(document.body, config);
 - React: [react-chess/chessground](https://github.com/react-chess/chessground), [ruilisi/react-chessground](https://github.com/ruilisi/react-chessground)
 - Vue.js: [vitogit/vue-chessboard](https://github.com/vitogit/vue-chessboard), [qwerty084/vue3-chessboard](https://github.com/qwerty084/vue3-chessboard)
 - Angular: [topce/ngx-chessground](https://github.com/topce/ngx-chessground)
-- Svelte: [gtim/svelte-chessground](https://github.com/gtim/svelte-chessground), [gtm-nayan/svelte-use-chessground](https://github.com/gtm-nayan/svelte-use-chessground)
+- Svelte: [agelas/svelte-chessground-ui](https://github.com/agelas/svelte-chessground-ui), [gtim/svelte-chessground](https://github.com/gtim/svelte-chessground), [gtm-nayan/svelte-use-chessground](https://github.com/gtm-nayan/svelte-use-chessground)
 
 More? Please make a pull request to include it here.
 


### PR DESCRIPTION
Hi, this adds a link to svelte-chessground-ui in the list of svelte wrappers. This one is compatible with Svelte ^4.0.0 and uses chessground ^9.1.1, the other ones are a bit outdated.