### PR TITLE
fix: enable CSS file imports from chessground assets in Next.js projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "chessground.d.ts",
   "exports": {
     ".": "./dist/chessground.js",
+    "./assets/*": "./assets/*",
     "./*": "./dist/*.js"
   },
   "typesVersions": {


### PR DESCRIPTION
Changes:
- Updated `package.json` to include the following line in the exports field:
```json
 "./assets/*": "./assets/*"
```
- This change ensures that CSS files can be resolved correctly when importing from the chessground package.