### PR TITLE
shadowMove

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface Config {
       afterNewPiece?: (role: cg.Role, key: cg.Key, metadata: cg.MoveMetadata) => void; // called after a new piece is dropped on the board
     };
     rookCastle?: boolean; // castle by moving the king to the rook
+    shadowMove?: boolean; //allow move without moving pieces on the board (just selecting squares)
   };
   premovable?: {
     enabled?: boolean; // allow premoves for color that can not move

--- a/src/state.ts
+++ b/src/state.ts
@@ -43,6 +43,7 @@ export interface HeadlessState {
       afterNewPiece?: (role: cg.Role, key: cg.Key, metadata: cg.MoveMetadata) => void; // called after a new piece is dropped on the board
     };
     rookCastle: boolean; // castle by moving the king to the rook
+    shadowMove?: boolean; //allow move without moving pieces on the board (just selecting squares)
   };
   premovable: {
     enabled: boolean; // allow premoves for color that can not move
@@ -137,6 +138,7 @@ export function defaults(): HeadlessState {
       showDests: true,
       events: {},
       rookCastle: true,
+      shadowMove: false,
     },
     premovable: {
       enabled: true,


### PR DESCRIPTION
This implements shadowMove for chessground, which will allow to execute a move wihtout touching to pieces. This is required to implement "half blinded puzzle". I added a lot of details in the corresponding PR in lila  : https://github.com/lichess-org/lila/pull/17158