### PR TITLE
Fix radial gradient antialiasing

### DIFF
--- a/assets/chessground.brown.css
+++ b/assets/chessground.brown.css
@@ -6,16 +6,16 @@ cg-board {
 
 /** Interactive board square colors */
 cg-board square.move-dest {
-  background: radial-gradient(rgba(20, 85, 30, 0.5) 22%, rgba(20, 85, 30, 0) calc(22% + 1px));
+  background: radial-gradient(rgba(20, 85, 30, 0.5) calc(22% - 0.5px), rgba(20, 85, 30, 0) calc(22% + 0.5px));
 }
 cg-board square.premove-dest {
-  background: radial-gradient(rgba(20, 30, 85, 0.5) 22%, rgba(20, 30, 85, 0) calc(22% + 1px));
+  background: radial-gradient(rgba(20, 30, 85, 0.5) calc(22% - 0.5px), rgba(20, 30, 85, 0) calc(22% + 0.5px));
 }
 cg-board square.oc.move-dest {
-  background: radial-gradient(transparent 0%, rgba(20, 85, 0, 0) calc(80% - 1px), rgba(20, 85, 0, 0.3) 80%);
+  background: radial-gradient(transparent 0%, rgba(20, 85, 0, 0) calc(80% - 0.5px), rgba(20, 85, 0, 0.3) calc(80% + 0.5px));
 }
 cg-board square.oc.premove-dest {
-  background: radial-gradient(transparent 0%, rgba(20, 30, 85, 0.2) calc(80% - 1px), rgba(20, 30, 85, 0.2) 80%);
+  background: radial-gradient(transparent 0%, rgba(20, 30, 85, 0.2) calc(80% - 0.5px), rgba(20, 30, 85, 0.2) calc(80% + 0.5px));
 }
 cg-board square.move-dest:hover {
   background: rgba(20, 85, 30, 0.3);


### PR DESCRIPTION
The available moves and capture indicators are done using radial gradients, and suffer from lack of proper antialiasing. This is more apparent at small board sizes:

![image](https://github.com/user-attachments/assets/6e184839-02c8-46f8-bec5-b6d0751a7f3c)

The fix is to not apply a hard stop, but to add a 1px transition to transparent, as described in https://stackoverflow.com/a/40261626/4851350

![image](https://github.com/user-attachments/assets/ed0b4d4e-d873-430b-bffd-9d30f0c32cdc)

Interestingly, lichess.org already attempts to do that (and uses 19% instead of 22% for the move destination indicator?), but only uses a 1% offset, which is equivalent to 0px on low resolutions.