### PR TITLE
Make a shallow copy of the `shapes` param in `setShapes`.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -165,7 +165,7 @@ export function start(state: State, redrawAll: cg.Redraw): Api {
     },
 
     setShapes(shapes: DrawShape[]): void {
-      render(state => (state.drawable.shapes = shapes), state);
+      render(state => (state.drawable.shapes = shapes.slice()), state);
     },
 
     getKeyAtDomPos(pos): cg.Key | undefined {


### PR DESCRIPTION
Prevents the user's shape list from being modified if chessground's `state.drawable.shapes` subsequently changes (which it does in `draw.ts` with the push statement).

I should note that technically this change has backwards compatibility issues; it's possible someone could (either deliberately or not) be relying on chessground modifying the list in a certain way.