### PR TITLE
publish chessground from github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version string matching /v[0-9]+\\.[0-9]+\\.[0-9]+/ (e.g. v1.2.3)"
+        required: true
+      description:
+        description: "Description"
+        required: false
+        default: ""
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - run: |
+          [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]] || \
+          (echo "Version must match /v[0-9]+\\.[0-9]+\\.[0-9]+/ (e.g. v1.2.3)" && exit 1)
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: true
+      - run: |
+          pnpm run dist
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          NPM_VERSION="${GITHUB_VERSION#v}"
+          pnpm version "$NPM_VERSION"
+          git push origin HEAD --follow-tags
+        env:
+          GITHUB_VERSION: ${{ github.event.inputs.version }}
+      
+      - name: Publish to npm
+        run: pnpm publish --provenance --access public --dry-run
+
+      - name: Publish to github
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          name: Release ${{ github.event.inputs.version }}
+          body: ${{ github.event.inputs.description }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
           [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]] || \
           (echo "Version must start with 'v' and match 'v<major>.<minor>.<patch>'" && exit 1)
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@v4
         with:
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version string matching /v[0-9]+\\.[0-9]+\\.[0-9]+/ (e.g. v1.2.3)"
+        description: 'Version tag (e.g. v1.2.3)'
         required: true
       description:
-        description: "Description"
+        description: 'Description'
         required: false
-        default: ""
+        default: ''
 
 jobs:
   release:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - run: |
           [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]] || \
-          (echo "Version must match /v[0-9]+\\.[0-9]+\\.[0-9]+/ (e.g. v1.2.3)" && exit 1)
+          (echo "Version must start with 'v' and match 'v<major>.<minor>.<patch>'" && exit 1)
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -38,9 +38,9 @@ jobs:
           git push origin HEAD --follow-tags
         env:
           GITHUB_VERSION: ${{ github.event.inputs.version }}
-      
+
       - name: Publish to npm
-        run: pnpm publish --provenance --access public --dry-run
+        run: pnpm publish --provenance --access public
 
       - name: Publish to github
         uses: softprops/action-gh-release@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lichess-org/chessground",
-  "version": "9.2.1",
+  "version": "0.0.0-test",
   "description": "lichess.org chess ui",
   "type": "module",
   "main": "dist/chessground.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lichess-org/chessground",
-  "version": "0.0.0-test",
+  "version": "0.0.1-test",
   "description": "lichess.org chess ui",
   "type": "module",
   "main": "dist/chessground.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chessground",
+  "name": "@lichess-org/chessground",
   "version": "9.2.1",
   "description": "lichess.org chess ui",
   "type": "module",


### PR DESCRIPTION
- "Release" will show up in actions tab
![image](https://github.com/user-attachments/assets/e31c4af0-6028-4739-b095-9df7ba374038)
- i've only tested with `pnpm publish --dry-run`, but theoretically it will publish to npm once the NODE_AUTH_TOKEN secret is added (i don't have admin on chessground to do this)
- after we've cut our first @lichess-org/chessground package, you should:
```
npm deprecate chessground@"*" "This package has moved to @lichess-org/chessground. Please update your dependencies."
```
