### PR TITLE
Trim premoves - epilogue

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "root": true,
   "env": {
     "browser": true,
-    "es2017": true
+    "es2020": true
   },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,7 @@ export interface Config {
     castle?: boolean; // whether to allow king castle premoves
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
-    premoveThroughFriendlies?: boolean; // if falsy, the positions of friendly pieces will be used to trim premove options
+    unrestrictedPremoves?: boolean; // if falsy, the positions of friendly pieces will be used to trim premove options
     events?: {
       set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
       unset?: () => void; // called after the premove has been unset

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -122,12 +122,15 @@ const isPathClearEnoughOfEnemiesForPremove = (ctx: MobilityContext): boolean => 
   const enemySquare = squaresOfEnemiesBetween[0];
   const enemy = ctx.enemies.get(enemySquare)!;
   if (enemy.role !== 'pawn') return true;
-  const squareAbove = util.squareShiftedVertically(enemySquare, enemy.color === 'white' ? 1 : -1);
-  const enemyPawnDests: cg.Key[] = [];
-  if (canEnemyPawnAdvanceToSquare(enemySquare, squareAbove, ctx)) enemyPawnDests.push(squareAbove);
-  enemyPawnDests.push(
+
+  const enemyStep = enemy.color === 'white' ? 1 : -1;
+  const squareAbove = util.squareShiftedVertically(enemySquare, enemyStep);
+  const enemyPawnDests: cg.Key[] = [
     ...util.adjacentSquares(squareAbove).filter(s => canEnemyPawnCaptureOnSquare(enemySquare, s, ctx)),
-  );
+    ...[squareAbove, util.squareShiftedVertically(squareAbove, enemyStep)].filter(s =>
+      canEnemyPawnAdvanceToSquare(enemySquare, s, ctx),
+    ),
+  ];
   const badSquares = [...squaresBetween, util.pos2key(ctx.pos1)];
   return enemyPawnDests.some(square => !badSquares.includes(square));
 };

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -18,12 +18,12 @@ type MobilityContext = {
 type Mobility = (ctx: MobilityContext) => boolean;
 
 const isDestOccupiedByFriendly = (ctx: MobilityContext): boolean =>
-  !!ctx.friendlies.get(util.pos2key(ctx.pos2));
+  ctx.friendlies.has(util.pos2key(ctx.pos2));
 
-const isDestOccupiedByEnemy = (ctx: MobilityContext): boolean => !!ctx.enemies.get(util.pos2key(ctx.pos2));
+const isDestOccupiedByEnemy = (ctx: MobilityContext): boolean => ctx.enemies.has(util.pos2key(ctx.pos2));
 
 const anyPieceBetween = (pos1: cg.Pos, pos2: cg.Pos, pieces: cg.Pieces): boolean =>
-  util.squaresBetween(...pos1, ...pos2).some(s => pieces.get(s));
+  util.squaresBetween(...pos1, ...pos2).some(s => pieces.has(s));
 
 const canEnemyPawnAdvanceToSquare = (pawnStart: cg.Key, dest: cg.Key, ctx: MobilityContext): boolean => {
   const piece = ctx.enemies.get(pawnStart);
@@ -42,7 +42,7 @@ const canEnemyPawnCaptureOnSquare = (pawnStart: cg.Key, dest: cg.Key, ctx: Mobil
   return (
     enemyPawn?.role === 'pawn' &&
     util.pawnDirCapture(...util.key2pos(pawnStart), ...util.key2pos(dest), enemyPawn.color === 'white') &&
-    (!!ctx.friendlies.get(dest) ||
+    (ctx.friendlies.has(dest) ||
       canBeCapturedBySomeEnemyEnPassant(
         util.squareShiftedVertically(dest, enemyPawn.color === 'white' ? -1 : 1),
         ctx.friendlies,
@@ -97,7 +97,7 @@ const canBeCapturedBySomeEnemyEnPassant = (
 const isPathClearEnoughOfFriendliesForPremove = (ctx: MobilityContext): boolean => {
   if (ctx.unrestrictedPremoves) return true;
   const squaresBetween = util.squaresBetween(...ctx.pos1, ...ctx.pos2);
-  const squaresOfFriendliesBetween = squaresBetween.filter(s => ctx.friendlies.get(s));
+  const squaresOfFriendliesBetween = squaresBetween.filter(s => ctx.friendlies.has(s));
   return (
     !squaresOfFriendliesBetween.length ||
     (squaresOfFriendliesBetween.length === 1 &&
@@ -116,12 +116,12 @@ const isPathClearEnoughOfFriendliesForPremove = (ctx: MobilityContext): boolean 
 const isPathClearEnoughOfEnemiesForPremove = (ctx: MobilityContext): boolean => {
   if (ctx.unrestrictedPremoves) return true;
   const squaresBetween = util.squaresBetween(...ctx.pos1, ...ctx.pos2);
-  const squaresOfEnemiesBetween = squaresBetween.filter(s => ctx.enemies.get(s));
+  const squaresOfEnemiesBetween = squaresBetween.filter(s => ctx.enemies.has(s));
   if (squaresOfEnemiesBetween.length > 1) return false;
   if (!squaresOfEnemiesBetween.length) return true;
   const enemySquare = squaresOfEnemiesBetween[0];
-  const enemy = ctx.enemies.get(enemySquare)!;
-  if (enemy.role !== 'pawn') return true;
+  const enemy = ctx.enemies.get(enemySquare);
+  if (!enemy || enemy.role !== 'pawn') return true;
 
   const enemyStep = enemy.color === 'white' ? 1 : -1;
   const squareAbove = util.squareShiftedVertically(enemySquare, enemyStep);

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -2,114 +2,201 @@ import * as util from './util.js';
 import * as cg from './types.js';
 import { HeadlessState } from './state.js';
 
-type Mobility = (x1: number, y1: number, x2: number, y2: number) => boolean;
+type MobilityContext = {
+  pos1: cg.Pos;
+  pos2: cg.Pos;
+  allPieces: cg.Pieces;
+  friendlies: cg.Pieces;
+  enemies: cg.Pieces;
+  premoveThroughFriendlies: boolean;
+  color: cg.Color;
+  lastMove: cg.Key[] | undefined;
+};
 
-const isPathClearEnoughForPremove = (
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-  pieces: cg.Pieces,
-  color: cg.Color,
-  premoveThroughFriendlies: boolean,
+type Mobility = (ctx: MobilityContext) => boolean;
+
+const isDestOccupiedByFriendly = (ctx: MobilityContext): boolean =>
+  !!ctx.friendlies.get(util.pos2key(ctx.pos2));
+
+const isDestOccupiedByEnemy = (ctx: MobilityContext): boolean => !!ctx.enemies.get(util.pos2key(ctx.pos2));
+
+const anyPieceBetween = (pos1: cg.Pos, pos2: cg.Pos, pieces: cg.Pieces): boolean =>
+  util.squaresBetween(...pos1, ...pos2).some(s => pieces.get(s));
+
+const canEnemyPawnAdvanceToSquare = (pawnStart: cg.Key, dest: cg.Key, ctx: MobilityContext): boolean => {
+  const piece = ctx.enemies.get(pawnStart);
+  if (piece?.role !== 'pawn') return false;
+  const step = piece.color === 'white' ? 1 : -1;
+  const startPos = util.key2pos(pawnStart);
+  const destPos = util.key2pos(dest);
+  return (
+    util.pawnDirAdvance(...startPos, ...destPos, piece.color === 'white') &&
+    !anyPieceBetween(startPos, [destPos[0], destPos[1] + step], ctx.allPieces)
+  );
+};
+
+const canEnemyPawnCaptureOnSquare = (pawnStart: cg.Key, dest: cg.Key, ctx: MobilityContext): boolean => {
+  const enemyPawn = ctx.enemies.get(pawnStart);
+  return (
+    enemyPawn?.role === 'pawn' &&
+    util.pawnDirCapture(...util.key2pos(pawnStart), ...util.key2pos(dest), enemyPawn.color === 'white') &&
+    (!!ctx.friendlies.get(dest) ||
+      canBeCapturedBySomeEnemyEnPassant(
+        util.squareShiftedVertically(dest, enemyPawn.color === 'white' ? -1 : 1),
+        ctx.friendlies,
+        ctx.enemies,
+        ctx.lastMove,
+      ))
+  );
+};
+
+const canSomeEnemyPawnAdvanceToDest = (ctx: MobilityContext): boolean =>
+  [...ctx.enemies.keys()].some(key => canEnemyPawnAdvanceToSquare(key, util.pos2key(ctx.pos2), ctx));
+
+const isDestControlledByEnemy = (ctx: MobilityContext, pieceRolesExclude?: cg.Role[]): boolean => {
+  const square: cg.Pos = ctx.pos2;
+  return [...ctx.enemies].some(([key, piece]) => {
+    const piecePos = util.key2pos(key);
+    return (
+      !pieceRolesExclude?.includes(piece.role) &&
+      ((piece.role === 'pawn' && util.pawnDirCapture(...piecePos, ...square, piece.color === 'white')) ||
+        (piece.role === 'knight' && util.knightDir(...piecePos, ...square)) ||
+        (piece.role === 'bishop' && util.bishopDir(...piecePos, ...square)) ||
+        (piece.role === 'rook' && util.rookDir(...piecePos, ...square)) ||
+        (piece.role === 'queen' && util.queenDir(...piecePos, ...square)) ||
+        (piece.role === 'king' && util.kingDirNonCastling(...piecePos, ...square))) &&
+      (!['bishop', 'rook', 'queen'].includes(piece.role) || !anyPieceBetween(piecePos, square, ctx.allPieces))
+    );
+  });
+};
+
+const isFriendlyOnDestAndAttacked = (ctx: MobilityContext): boolean =>
+  isDestOccupiedByFriendly(ctx) &&
+  (canBeCapturedBySomeEnemyEnPassant(util.pos2key(ctx.pos2), ctx.friendlies, ctx.enemies, ctx.lastMove) ||
+    isDestControlledByEnemy(ctx));
+
+const canBeCapturedBySomeEnemyEnPassant = (
+  squareOfFriendlyPawn: cg.Key,
+  friendlies: cg.Pieces,
+  enemies: cg.Pieces,
   lastMove?: cg.Key[],
 ): boolean => {
-  if (premoveThroughFriendlies) return true;
-  const squares = util.squaresBetween(x1, y1, x2, y2);
-  const squaresOfFriendliesBetween = squares.filter(s => pieces.get(s)?.color === color);
-  if (
-    squaresOfFriendliesBetween.length > 1 ||
-    squares.filter(s => pieces.get(s)?.color === util.opposite(color)).length > 1
-  )
-    return false;
-  if (!squaresOfFriendliesBetween.length) return true;
-  if (!lastMove || squaresOfFriendliesBetween[0] !== lastMove[1]) return false;
-  const destKey = lastMove[1],
-    srcPos = util.key2pos(lastMove[0]),
-    destPos = util.key2pos(destKey),
-    piece = pieces.get(destKey)!;
+  if (!lastMove || squareOfFriendlyPawn !== lastMove[1]) return false;
+  const srcPos = util.key2pos(lastMove[0]),
+    destPos = util.key2pos(lastMove[1]),
+    piece = friendlies.get(lastMove[1])!;
   return (
     piece.role === 'pawn' &&
     util.diff(srcPos[1], destPos[1]) === 2 &&
     [1, -1].some(delta => {
-      const enemyPiece = pieces.get(util.pos2key([destPos[0] + delta, destPos[1]]));
-      return enemyPiece?.role === 'pawn' && enemyPiece.color === util.opposite(piece.color);
+      const enemyPiece = enemies.get(util.pos2key([destPos[0] + delta, destPos[1]]));
+      return enemyPiece?.role === 'pawn';
     })
   );
 };
 
-const pawn =
-  (pieces: cg.Pieces, color: cg.Color, premoveThroughFriendlies: boolean): Mobility =>
-  (x1, y1, x2, y2) => {
-    const step = color === 'white' ? 1 : -1;
-    if (util.diff(x1, x2) === 1) return y2 === y1 + step;
+const isPathClearEnoughOfFriendliesForPremove = (ctx: MobilityContext): boolean => {
+  if (ctx.premoveThroughFriendlies) return true;
+  const squaresBetween = util.squaresBetween(...ctx.pos1, ...ctx.pos2);
+  const squaresOfFriendliesBetween = squaresBetween.filter(s => ctx.friendlies.get(s));
+  return (
+    !squaresOfFriendliesBetween.length ||
+    (squaresOfFriendliesBetween.length === 1 &&
+      canBeCapturedBySomeEnemyEnPassant(
+        squaresOfFriendliesBetween[0],
+        ctx.friendlies,
+        ctx.enemies,
+        ctx.lastMove,
+      ) &&
+      !squaresBetween.includes(
+        util.squareShiftedVertically(squaresOfFriendliesBetween[0], ctx.color === 'white' ? -1 : 1),
+      ))
+  );
+};
+
+const isPathClearEnoughOfEnemiesForPremove = (ctx: MobilityContext): boolean => {
+  if (ctx.premoveThroughFriendlies) return true;
+  const squaresBetween = util.squaresBetween(...ctx.pos1, ...ctx.pos2);
+  const squaresOfEnemiesBetween = squaresBetween.filter(s => ctx.enemies.get(s));
+  if (squaresOfEnemiesBetween.length > 1) return false;
+  if (!squaresOfEnemiesBetween.length) return true;
+  const enemySquare = squaresOfEnemiesBetween[0];
+  const enemy = ctx.enemies.get(enemySquare)!;
+  if (enemy.role !== 'pawn') return true;
+  const squareAbove = util.squareShiftedVertically(enemySquare, enemy.color === 'white' ? 1 : -1);
+  const enemyPawnDests: cg.Key[] = [];
+  if (canEnemyPawnAdvanceToSquare(enemySquare, squareAbove, ctx)) enemyPawnDests.push(squareAbove);
+  enemyPawnDests.push(
+    ...util.adjacentSquares(squareAbove).filter(s => canEnemyPawnCaptureOnSquare(enemySquare, s, ctx)),
+  );
+  const badSquares = [...squaresBetween, util.pos2key(ctx.pos1)];
+  return enemyPawnDests.some(square => !badSquares.includes(square));
+};
+
+const isPathClearEnoughForPremove = (ctx: MobilityContext): boolean =>
+  isPathClearEnoughOfFriendliesForPremove(ctx) && isPathClearEnoughOfEnemiesForPremove(ctx);
+
+const pawn: Mobility = (ctx: MobilityContext) => {
+  const step = ctx.color === 'white' ? 1 : -1;
+  if (util.diff(ctx.pos1[0], ctx.pos2[0]) > 1) return false;
+  if (!util.diff(ctx.pos1[0], ctx.pos2[0])) {
     return (
-      x1 === x2 &&
-      (y2 === y1 + step ||
-        // allow 2 squares from first two ranks, for horde
-        (y2 === y1 + 2 * step && (color === 'white' ? y1 <= 1 : y1 >= 6))) &&
-      isPathClearEnoughForPremove(x1, y1, x2, y2 + step, pieces, color, premoveThroughFriendlies)
+      util.pawnDirAdvance(...ctx.pos1, ...ctx.pos2, ctx.color === 'white') &&
+      isPathClearEnoughForPremove({ ...ctx, pos2: [ctx.pos2[0], ctx.pos2[1] + step] })
     );
-  };
+  }
+  if (ctx.pos2[1] !== ctx.pos1[1] + step) return false;
+  // todo - change name of premoveThroughFriendlies, since concept has expanded
+  if (ctx.premoveThroughFriendlies || isDestOccupiedByEnemy(ctx)) return true;
+  if (isDestOccupiedByFriendly(ctx)) return isDestControlledByEnemy(ctx);
+  else
+    return (
+      canSomeEnemyPawnAdvanceToDest(ctx) ||
+      canBeCapturedBySomeEnemyEnPassant(
+        util.pos2key([ctx.pos2[0], ctx.pos2[1] + step]),
+        ctx.friendlies,
+        ctx.enemies,
+        ctx.lastMove,
+      ) ||
+      isDestControlledByEnemy(ctx, ['pawn'])
+    );
+};
 
-const knight: Mobility = (x1, y1, x2, y2) => util.knightDir(x1, y1, x2, y2);
+const knight: Mobility = (ctx: MobilityContext) =>
+  util.knightDir(...ctx.pos1, ...ctx.pos2) &&
+  (ctx.premoveThroughFriendlies || !isDestOccupiedByFriendly(ctx) || isFriendlyOnDestAndAttacked(ctx));
 
-const bishop =
-  (
-    pieces: cg.Pieces,
-    color: cg.Color,
-    premoveThroughFriendlies: boolean,
-    lastMove: cg.Key[] | undefined,
-  ): Mobility =>
-  (x1, y1, x2, y2) =>
-    util.bishopDir(x1, y1, x2, y2) &&
-    isPathClearEnoughForPremove(x1, y1, x2, y2, pieces, color, premoveThroughFriendlies, lastMove);
+const bishop: Mobility = (ctx: MobilityContext) =>
+  util.bishopDir(...ctx.pos1, ...ctx.pos2) &&
+  isPathClearEnoughForPremove(ctx) &&
+  (ctx.premoveThroughFriendlies || !isDestOccupiedByFriendly(ctx) || isFriendlyOnDestAndAttacked(ctx));
 
-const rook =
-  (
-    pieces: cg.Pieces,
-    color: cg.Color,
-    premoveThroughFriendlies: boolean,
-    lastMove: cg.Key[] | undefined,
-  ): Mobility =>
-  (x1, y1, x2, y2) =>
-    util.rookDir(x1, y1, x2, y2) &&
-    isPathClearEnoughForPremove(x1, y1, x2, y2, pieces, color, premoveThroughFriendlies, lastMove);
+const rook: Mobility = (ctx: MobilityContext) =>
+  util.rookDir(...ctx.pos1, ...ctx.pos2) &&
+  isPathClearEnoughForPremove(ctx) &&
+  (ctx.premoveThroughFriendlies || !isDestOccupiedByFriendly(ctx) || isFriendlyOnDestAndAttacked(ctx));
 
-const queen =
-  (
-    pieces: cg.Pieces,
-    color: cg.Color,
-    premoveThroughFriendlies: boolean,
-    lastMove: cg.Key[] | undefined,
-  ): Mobility =>
-  (x1, y1, x2, y2) =>
-    bishop(pieces, color, premoveThroughFriendlies, lastMove)(x1, y1, x2, y2) ||
-    rook(pieces, color, premoveThroughFriendlies, lastMove)(x1, y1, x2, y2);
+const queen: Mobility = (ctx: MobilityContext) => bishop(ctx) || rook(ctx);
 
 const king =
-  (
-    pieces: cg.Pieces,
-    color: cg.Color,
-    premoveThroughFriendlies: boolean,
-    rookFiles: number[],
-    canCastle: boolean,
-  ): Mobility =>
-  (x1, y1, x2, y2) =>
-    Math.max(util.diff(x1, x2), util.diff(y1, y2)) === 1 ||
+  (rookFiles: number[], canCastle: boolean): Mobility =>
+  (ctx: MobilityContext) =>
+    (util.kingDirNonCastling(...ctx.pos1, ...ctx.pos2) &&
+      (ctx.premoveThroughFriendlies || !isDestOccupiedByFriendly(ctx) || isFriendlyOnDestAndAttacked(ctx))) ||
     (canCastle &&
-      y1 === y2 &&
-      y1 === (color === 'white' ? 0 : 7) &&
-      ((x1 === 4 && ((x2 === 2 && rookFiles.includes(0)) || (x2 === 6 && rookFiles.includes(7)))) ||
-        rookFiles.includes(x2)) &&
-      (premoveThroughFriendlies ||
+      ctx.pos1[1] === ctx.pos2[1] &&
+      ctx.pos1[1] === (ctx.color === 'white' ? 0 : 7) &&
+      ((ctx.pos1[0] === 4 &&
+        ((ctx.pos2[0] === 2 && rookFiles.includes(0)) || (ctx.pos2[0] === 6 && rookFiles.includes(7)))) ||
+        rookFiles.includes(ctx.pos2[0])) &&
+      (ctx.premoveThroughFriendlies ||
         /* The following checks if no non-rook friendly piece is in the way between the king and its castling destination.
          Note that for the Chess960 edge case of Kb1 "long castling", the check passes even if there is a piece in the way
          on c1. But this is fine, since premoving from b1 to a1 as a normal move would have already returned true. */
         util
-          .squaresBetween(x1, y1, x2 > x1 ? 7 : 1, y2)
-          .map(s => pieces.get(s))
-          .every(p => !p || util.samePiece(p, { role: 'rook', color: color }))));
+          .squaresBetween(...ctx.pos1, ctx.pos2[0] > ctx.pos1[0] ? 7 : 1, ctx.pos2[1])
+          .map(s => ctx.allPieces.get(s))
+          .every(p => !p || util.samePiece(p, { role: 'rook', color: ctx.color }))));
 
 const rookFilesOf = (pieces: cg.Pieces, color: cg.Color) => {
   const backrank = color === 'white' ? '1' : '8';
@@ -127,26 +214,35 @@ export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
     canCastle = state.premovable.castle,
     premoveThroughFriendlies = !!state.premovable.premoveThroughFriendlies;
   const piece = pieces.get(key);
-  if (!piece) return [];
+  if (!piece || piece.color === state.turnColor) return [];
+  const friendlies = new Map([...pieces].filter(([_, p]) => p.color === piece.color));
+  const enemies = new Map([...pieces].filter(([_, p]) => p.color === util.opposite(piece.color)));
   const pos = util.key2pos(key),
     r = piece.role,
     mobility: Mobility =
       r === 'pawn'
-        ? pawn(pieces, piece.color, premoveThroughFriendlies)
+        ? pawn
         : r === 'knight'
           ? knight
           : r === 'bishop'
-            ? bishop(pieces, piece.color, premoveThroughFriendlies, state.lastMove)
+            ? bishop
             : r === 'rook'
-              ? rook(pieces, piece.color, premoveThroughFriendlies, state.lastMove)
+              ? rook
               : r === 'queen'
-                ? queen(pieces, piece.color, premoveThroughFriendlies, state.lastMove)
-                : king(
-                    pieces,
-                    piece.color,
-                    premoveThroughFriendlies,
-                    rookFilesOf(pieces, piece.color),
-                    canCastle,
-                  );
-  return util.allPos.filter(pos2 => mobility(pos[0], pos[1], pos2[0], pos2[1])).map(util.pos2key);
+                ? queen
+                : king(rookFilesOf(pieces, piece.color), canCastle);
+  return util.allPos
+    .filter(pos2 =>
+      mobility({
+        pos1: pos,
+        pos2: pos2,
+        allPieces: pieces,
+        friendlies: friendlies,
+        enemies: enemies,
+        premoveThroughFriendlies: premoveThroughFriendlies,
+        color: piece.color,
+        lastMove: state.lastMove,
+      }),
+    )
+    .map(util.pos2key);
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,7 +51,7 @@ export interface HeadlessState {
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
     current?: cg.KeyPair; // keys of the current saved premove ["e2" "e4"]
-    premoveThroughFriendlies?: boolean; // if falsy, the positions of friendly pieces will be used to trim premove options
+    unrestrictedPremoves?: boolean; // if falsy, the positions of friendly pieces will be used to trim premove options
     events: {
       set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
       unset?: () => void; // called after the premove has been unset

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,9 +2,7 @@ import * as cg from './types.js';
 
 export const invRanks: readonly cg.Rank[] = [...cg.ranks].reverse();
 
-export const allKeys: readonly cg.Key[] = Array.prototype.concat(
-  ...cg.files.map(c => cg.ranks.map(r => c + r)),
-);
+export const allKeys: readonly cg.Key[] = cg.files.flatMap(f => cg.ranks.map(r => (f + r) as cg.Key));
 
 export const pos2key = (pos: cg.Pos): cg.Key => allKeys[8 * pos[0] + pos[1]];
 
@@ -114,6 +112,22 @@ export const bishopDir: cg.DirectionalCheck = (x1, y1, x2, y2) => diff(x1, x2) =
 export const queenDir: cg.DirectionalCheck = (x1, y1, x2, y2) =>
   rookDir(x1, y1, x2, y2) || bishopDir(x1, y1, x2, y2);
 
+export const kingDirNonCastling: cg.DirectionalCheck = (x1, y1, x2, y2) =>
+  Math.max(diff(x1, x2), diff(y1, y2)) === 1;
+
+export const pawnDirCapture = (x1: number, y1: number, x2: number, y2: number, isDirectionUp: boolean) =>
+  diff(x1, x2) === 1 && y2 === y1 + (isDirectionUp ? 1 : -1);
+
+export const pawnDirAdvance = (x1: number, y1: number, x2: number, y2: number, isDirectionUp: boolean) => {
+  const step = isDirectionUp ? 1 : -1;
+  return (
+    x1 === x2 &&
+    (y2 === y1 + step ||
+      // allow 2 squares from first two ranks, for horde
+      (y2 === y1 + 2 * step && (isDirectionUp ? y1 <= 1 : y1 >= 6)))
+  );
+};
+
 /** Returns all board squares between (x1, y1) and (x2, y2) exclusive,
  *  along a straight line (rook or bishop path). Returns [] if not aligned, or none between.
  */
@@ -135,4 +149,18 @@ export const squaresBetween = (x1: number, y1: number, x2: number, y2: number): 
     y += stepY;
   }
   return squares.map(sq => pos2key(sq));
+};
+
+export const adjacentSquares = (square: cg.Key): cg.Key[] => {
+  const pos = key2pos(square);
+  const adjacentSquares: cg.Pos[] = [];
+  if (pos[0] > 0) adjacentSquares.push([pos[0] - 1, pos[1]]);
+  if (pos[0] < 7) adjacentSquares.push([pos[0] + 1, pos[1]]);
+  return adjacentSquares.map(pos2key);
+};
+
+export const squareShiftedVertically = (square: cg.Key, delta: number): cg.Key => {
+  const pos = key2pos(square);
+  pos[1] += delta;
+  return pos2key(pos);
 };

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -18,7 +18,7 @@ const makeState = (
 };
 
 test('premoves are trimmed appropriately', () => {
-  const state = makeState('k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/1bnP2KP/R4r1q w - - 0 1', true, [
+  const state = makeState('k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/PbnP2KP/R4r1q w - - 0 1', true, [
     'e7',
     'e5',
   ]);
@@ -36,7 +36,7 @@ test('premoves are trimmed appropriately', () => {
   );
   expect(new Set(premove(state, 'h8'))).toEqual(new Set(['h7', 'g8']));
   expect(new Set(premove(state, 'e3'))).toEqual(
-    new Set(['g3', 'f3', 'd3', 'c3', 'b3', 'a3', 'e2', 'e1', 'e4', 'e5', 'e6']),
+    new Set(['g3', 'f3', 'd3', 'c3', 'b3', 'e2', 'e1', 'e4', 'e5', 'e6']),
   );
   expect(new Set(premove(state, 'd6'))).toEqual(
     new Set(['e6', 'f6', 'g6', 'c6', 'b6', 'a6', 'd7', 'd8', 'd5', 'd4', 'd3', 'd2', 'd1']),
@@ -45,7 +45,7 @@ test('premoves are trimmed appropriately', () => {
     new Set(['h2', 'h3', 'h4', 'g1', 'f1', 'g2', 'f3', 'e4', 'd5', 'c6', 'b7']),
   );
   expect(new Set(premove(state, 'a4'))).toEqual(
-    new Set(['b3', 'b4', 'c4', 'd4', 'e4', 'f4', 'a5', 'a6', 'a3']),
+    new Set(['b3', 'b4', 'c4', 'd4', 'e4', 'f4', 'a5', 'a6']),
   );
   expect(new Set(premove(state, 'c5'))).toEqual(
     new Set(['c4', 'c3', 'd4', 'e3', 'd5', 'e5', 'f5', 'c6', 'b6', 'a7', 'b4']),
@@ -53,9 +53,14 @@ test('premoves are trimmed appropriately', () => {
   expect(new Set(premove(state, 'a8'))).toEqual(new Set(['b8', 'b7', 'a7']));
   expect(new Set(premove(state, 'c8'))).toEqual(new Set(['e7', 'b6', 'a7']));
   expect(new Set(premove(state, 'g4'))).toEqual(new Set(['h2', 'f6', 'e5', 'e3', 'f2']));
-  expect(new Set(premove(state, 'c2'))).toEqual(new Set(['e1', 'e3', 'd4', 'b4', 'a3', 'a1']));
-  expect(new Set(premove(state, 'b2'))).toEqual(new Set(['c1', 'a1', 'c3', 'd4', 'e5', 'f6', 'a3']));
+  expect(new Set(premove(state, 'c2'))).toEqual(new Set(['e1', 'e3', 'd4', 'b4', 'a1']));
+  expect(new Set(premove(state, 'b2'))).toEqual(new Set(['c1', 'a1', 'c3', 'd4', 'e5', 'f6']));
   expect(new Set(premove(state, 'c7'))).toEqual(new Set(['d8', 'b8', 'b6', 'a5']));
+  expect(new Set(premove(state, 'h6'))).toEqual(new Set(['h5']));
+  expect(new Set(premove(state, 'g7'))).toEqual(new Set(['g6', 'f6']));
+  expect(new Set(premove(state, 'e5'))).toEqual(new Set(['e4', 'd4']));
+  expect(new Set(premove(state, 'b5'))).toEqual(new Set(['b4']));
+  expect(new Set(premove(state, 'a3'))).toEqual(new Set([]));
 
   // todo - test more pieces
 

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -17,80 +17,46 @@ const makeState = (
   return state;
 };
 
-test('premoves are trimmed appropriately', () => {
-  const state = makeState('k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/PbnP2KP/R4r1q w - - 0 1', true, [
-    'e7',
-    'e5',
-  ]);
-  expect(new Set(premove(state, 'f8'))).toEqual(
-    new Set(['g8', 'e8', 'd8', 'c8', 'f7', 'f6', 'f5', 'f4', 'f3', 'f2', 'f1']),
-  );
-  expect(new Set(premove(state, 'f1'))).toEqual(
-    new Set(['h1', 'g1', 'e1', 'd1', 'c1', 'b1', 'a1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7']),
-  );
-  expect(new Set(premove(state, 'g5'))).toEqual(
-    new Set(
-      ['h5', 'f5', 'e5', 'd5', 'c5', 'g6'],
-      // technically premoving to c5 is impossible, but current expected behaviour allows it
-    ),
-  );
-  expect(new Set(premove(state, 'h8'))).toEqual(new Set(['h7', 'g8']));
-  expect(new Set(premove(state, 'e3'))).toEqual(
-    new Set(['g3', 'f3', 'd3', 'c3', 'b3', 'e2', 'e1', 'e4', 'e5', 'e6']),
-  );
-  expect(new Set(premove(state, 'd6'))).toEqual(
-    new Set(['e6', 'f6', 'g6', 'c6', 'b6', 'a6', 'd7', 'd8', 'd5', 'd4', 'd3', 'd2', 'd1']),
-  );
-  expect(new Set(premove(state, 'h1'))).toEqual(
-    new Set(['h2', 'h3', 'h4', 'g1', 'f1', 'g2', 'f3', 'e4', 'd5', 'c6', 'b7']),
-  );
-  expect(new Set(premove(state, 'a4'))).toEqual(
-    new Set(['b3', 'b4', 'c4', 'd4', 'e4', 'f4', 'a5', 'a6']),
-  );
-  expect(new Set(premove(state, 'c5'))).toEqual(
-    new Set(['c4', 'c3', 'd4', 'e3', 'd5', 'e5', 'f5', 'c6', 'b6', 'a7', 'b4']),
-  );
-  expect(new Set(premove(state, 'a8'))).toEqual(new Set(['b8', 'b7', 'a7']));
-  expect(new Set(premove(state, 'c8'))).toEqual(new Set(['e7', 'b6', 'a7']));
-  expect(new Set(premove(state, 'g4'))).toEqual(new Set(['h2', 'f6', 'e5', 'e3', 'f2']));
-  expect(new Set(premove(state, 'c2'))).toEqual(new Set(['e1', 'e3', 'd4', 'b4', 'a1']));
-  expect(new Set(premove(state, 'b2'))).toEqual(new Set(['c1', 'a1', 'c3', 'd4', 'e5', 'f6']));
-  expect(new Set(premove(state, 'c7'))).toEqual(new Set(['d8', 'b8', 'b6', 'a5']));
-  expect(new Set(premove(state, 'h6'))).toEqual(new Set(['h5']));
-  expect(new Set(premove(state, 'g7'))).toEqual(new Set(['g6', 'f6']));
-  expect(new Set(premove(state, 'e5'))).toEqual(new Set(['e4', 'd4']));
-  expect(new Set(premove(state, 'b5'))).toEqual(new Set(['b4']));
-  expect(new Set(premove(state, 'a3'))).toEqual(new Set([]));
-
-  // todo - test more pieces
-
+const testPosition = (
+  fenOfPos: cg.FEN,
+  lastMove: cg.Key[] | undefined,
+  expectedPremoves: Map<cg.Key, Set<cg.Key>>,
+): void => {
+  const state = makeState(fenOfPos, true, lastMove);
+  for (const [from, expectedDests] of expectedPremoves) {
+    expect(new Set(premove(state, from))).toEqual(expectedDests);
+  }
   expect(
-    util.allKeys
-      .filter(
-        sq =>
-          ![
-            'h8',
-            'h6',
-            'h1',
-            'g7',
-            'g5',
-            'g4',
-            'f8',
-            'f1',
-            'e5',
-            'e3',
-            'd6',
-            'c8',
-            'c7',
-            'c5',
-            'c2',
-            'b5',
-            'b2',
-            'a8',
-            'a4',
-            'a3',
-          ].includes(sq),
-      )
-      .every(square => !premove(state, square as cg.Key).length),
+    util.allKeys.filter(sq => !expectedPremoves.has(sq)).every(sq => !premove(state, sq as cg.Key).length),
   ).toEqual(true);
+};
+
+test('premoves are trimmed appropriately', () => {
+  const expectedPremoves = new Map<cg.Key, Set<cg.Key>>([
+    ['f8', new Set(['g8', 'e8', 'd8', 'c8', 'f7', 'f6', 'f5', 'f4', 'f3', 'f2', 'f1'])],
+    ['f1', new Set(['h1', 'g1', 'e1', 'd1', 'c1', 'b1', 'a1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7'])],
+    ['g5', new Set(['h5', 'f5', 'e5', 'd5', 'c5', 'g6'])],
+    ['h8', new Set(['h7', 'g8'])],
+    ['e3', new Set(['g3', 'f3', 'd3', 'c3', 'b3', 'e2', 'e1', 'e4', 'e5', 'e6'])],
+    ['d6', new Set(['e6', 'f6', 'g6', 'c6', 'b6', 'a6', 'd7', 'd8', 'd5', 'd4', 'd3', 'd2', 'd1'])],
+    ['h1', new Set(['h2', 'h3', 'h4', 'g1', 'f1', 'g2', 'f3', 'e4', 'd5', 'c6', 'b7'])],
+    ['a4', new Set(['b3', 'b4', 'c4', 'd4', 'e4', 'f4', 'a5', 'a6'])],
+    ['c5', new Set(['c4', 'c3', 'd4', 'e3', 'd5', 'e5', 'f5', 'c6', 'b6', 'a7', 'b4'])],
+    ['a8', new Set(['b8', 'b7', 'a7'])],
+    ['c8', new Set(['e7', 'b6', 'a7'])],
+    ['g4', new Set(['h2', 'f6', 'e5', 'e3', 'f2'])],
+    ['c2', new Set(['e1', 'e3', 'd4', 'b4', 'a1'])],
+    ['b2', new Set(['c1', 'a1', 'c3', 'd4', 'e5', 'f6'])],
+    ['c7', new Set(['d8', 'b8', 'b6', 'a5'])],
+    ['h6', new Set(['h5'])],
+    ['g7', new Set(['g6', 'f6'])],
+    ['e5', new Set(['e4', 'd4'])],
+    ['b5', new Set(['b4'])],
+    ['a3', new Set([])],
+  ]);
+  testPosition(
+    'k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/PbnP2KP/R4r1q w - - 0 1',
+    ['e7', 'e5'],
+    expectedPremoves,
+  );
 });

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -1,23 +1,75 @@
 import { premove } from '../src/premove';
 import * as cg from '../src/types';
+import { defaults, HeadlessState } from '../src/state';
+import * as fen from '../src/fen';
+import * as util from '../src/util';
 
-function createMockPieces(): cg.Pieces {
-  return new Map<cg.Key, cg.Piece>([
-    ['e4', { role: 'pawn', color: 'white' }],
-    ['e1', { role: 'rook', color: 'white' }],
-    ['g1', { role: 'rook', color: 'white' }],
-    ['d1', { role: 'king', color: 'white' }],
+const makeState = (
+  fenOfPos: cg.FEN,
+  trimPremoves: boolean,
+  lastMove: cg.Key[] | undefined,
+): HeadlessState => {
+  const state = defaults();
+  state.pieces = fen.read(fenOfPos);
+  if (!trimPremoves) state.premovable.unrestrictedPremoves = true;
+  state.lastMove = lastMove;
+  state.turnColor = fenOfPos.includes(' w ') ? 'white' : 'black';
+  return state;
+};
+
+test('premoves are trimmed appropriately', () => {
+  const state = makeState('k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/1bnP2KP/R4r1q w - - 0 1', true, [
+    'e7',
+    'e5',
   ]);
-}
-
-test('rook premoves behind friendlies by default', () => {
-  expect(new Set(premove(createMockPieces(), 'e1', false))).toEqual(
-    new Set(['d1', 'c1', 'b1', 'a1', 'f1', 'g1', 'h1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8']),
+  expect(new Set(premove(state, 'f8'))).toEqual(
+    new Set(['g8', 'e8', 'd8', 'c8', 'f7', 'f6', 'f5', 'f4', 'f3', 'f2', 'f1']),
   );
-});
-
-test('rook only premoves up to friendlies when specified', () => {
-  expect(new Set(premove(createMockPieces(), 'e1', false, true))).toEqual(
-    new Set(['d1', 'e2', 'e3', 'e4', 'f1', 'g1']),
+  expect(new Set(premove(state, 'f1'))).toEqual(
+    new Set(['h1', 'g1', 'e1', 'd1', 'c1', 'b1', 'a1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7']),
   );
+  expect(new Set(premove(state, 'g5'))).toEqual(
+    new Set(
+      ['h5', 'f5', 'e5', 'd5', 'c5', 'g6'],
+      // technically premoving to c5 is impossible, but current expected behaviour allows it
+    ),
+  );
+  expect(new Set(premove(state, 'h8'))).toEqual(new Set(['h7', 'g8']));
+  expect(new Set(premove(state, 'e3'))).toEqual(
+    new Set(['g3', 'f3', 'd3', 'c3', 'b3', 'a3', 'e2', 'e1', 'e4', 'e5', 'e6']),
+  );
+  expect(new Set(premove(state, 'd6'))).toEqual(
+    new Set(['e6', 'f6', 'g6', 'c6', 'b6', 'a6', 'd7', 'd8', 'd5', 'd4', 'd3', 'd2', 'd1']),
+  );
+  // todo - test other pieces
+
+  expect(
+    util.allKeys
+      .filter(
+        sq =>
+          ![
+            'h8',
+            'h6',
+            'h1',
+            'g7',
+            'g5',
+            'g4',
+            'f8',
+            'f1',
+            'e5',
+            'e3',
+            'd6',
+            'c8',
+            'c7',
+            'c5',
+            'c2',
+            'b5',
+            'b2',
+            'a8',
+            'a4',
+            'a3',
+          ].includes(sq),
+      )
+      .every(square => !premove(state, square as cg.Key).length),
+  ).toEqual(true);
 });

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -41,7 +41,23 @@ test('premoves are trimmed appropriately', () => {
   expect(new Set(premove(state, 'd6'))).toEqual(
     new Set(['e6', 'f6', 'g6', 'c6', 'b6', 'a6', 'd7', 'd8', 'd5', 'd4', 'd3', 'd2', 'd1']),
   );
-  // todo - test other pieces
+  expect(new Set(premove(state, 'h1'))).toEqual(
+    new Set(['h2', 'h3', 'h4', 'g1', 'f1', 'g2', 'f3', 'e4', 'd5', 'c6', 'b7']),
+  );
+  expect(new Set(premove(state, 'a4'))).toEqual(
+    new Set(['b3', 'b4', 'c4', 'd4', 'e4', 'f4', 'a5', 'a6', 'a3']),
+  );
+  expect(new Set(premove(state, 'c5'))).toEqual(
+    new Set(['c4', 'c3', 'd4', 'e3', 'd5', 'e5', 'f5', 'c6', 'b6', 'a7', 'b4']),
+  );
+  expect(new Set(premove(state, 'a8'))).toEqual(new Set(['b8', 'b7', 'a7']));
+  expect(new Set(premove(state, 'c8'))).toEqual(new Set(['e7', 'b6', 'a7']));
+  expect(new Set(premove(state, 'g4'))).toEqual(new Set(['h2', 'f6', 'e5', 'e3', 'f2']));
+  expect(new Set(premove(state, 'c2'))).toEqual(new Set(['e1', 'e3', 'd4', 'b4', 'a3', 'a1']));
+  expect(new Set(premove(state, 'b2'))).toEqual(new Set(['c1', 'a1', 'c3', 'd4', 'e5', 'f6', 'a3']));
+  expect(new Set(premove(state, 'c7'))).toEqual(new Set(['d8', 'b8', 'b6', 'a5']));
+
+  // todo - test more pieces
 
   expect(
     util.allKeys

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitReturns": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "target": "ES2017",
-    "lib": ["DOM", "ES2017"]
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"]
   }
 }


### PR DESCRIPTION
Trim premoves even more:

- Don't allow recapture premoves unless the friendly piece can be taken.
- If an enemy pawn is between the squares of a premove, only allow it if the pawn can get out of the way.
- Only allow pawns to premove diagonally if it's possible for them to capture an enemy on that square.

Also updates the test file, and upgrades chessground from ES2017 to ES2020 (I think this should be compatible with lichess?).