### PR TITLE
En passant edge cases

### DIFF
--- a/src/premove.ts
+++ b/src/premove.ts
@@ -78,19 +78,19 @@ const isFriendlyOnDestAndAttacked = (ctx: MobilityContext): boolean =>
     isDestControlledByEnemy(ctx));
 
 const canBeCapturedBySomeEnemyEnPassant = (
-  squareOfFriendlyPawn: cg.Key,
+  potentialSquareOfFriendlyPawn: cg.Key,
   friendlies: cg.Pieces,
   enemies: cg.Pieces,
   lastMove?: cg.Key[],
 ): boolean => {
-  if (!lastMove || squareOfFriendlyPawn !== lastMove[1]) return false;
-  const srcPos = util.key2pos(lastMove[0]),
-    destPos = util.key2pos(lastMove[1]),
-    piece = friendlies.get(lastMove[1])!;
+  if (lastMove && potentialSquareOfFriendlyPawn !== lastMove[1]) return false;
+  const pos = util.key2pos(potentialSquareOfFriendlyPawn);
+  const friendly = friendlies.get(potentialSquareOfFriendlyPawn);
   return (
-    piece.role === 'pawn' &&
-    util.diff(srcPos[1], destPos[1]) === 2 &&
-    [1, -1].some(delta => enemies.get(util.pos2key([destPos[0] + delta, destPos[1]]))?.role === 'pawn')
+    friendly?.role === 'pawn' &&
+    pos[1] === (friendly.color === 'white' ? 3 : 4) &&
+    (!lastMove || util.diff(util.key2pos(lastMove[0])[1], pos[1]) === 2) &&
+    [1, -1].some(delta => enemies.get(util.pos2key([pos[0] + delta, pos[1]]))?.role === 'pawn')
   );
 };
 

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -89,3 +89,37 @@ test('premoves are trimmed appropriately', () => {
     true,
   );
 });
+
+test('anticipate all en passant captures if no last move', () => {
+  const expectedPremoves = new Map<cg.Key, Set<cg.Key>>([
+    ['a2', new Set(['b1', 'b3', 'c4', 'd5', 'e6', 'f7', 'g8'])],
+    ['h2', new Set(['g1', 'g3', 'f4', 'e5', 'd6', 'c7', 'b8'])],
+    ['h3', new Set(['g3', 'f3', 'e3', 'd3', 'h4', 'h5'])],
+    ['f5', new Set(['e5', 'd5', 'c5', 'b5', 'a5', 'f6', 'f7', 'f8', 'f4', 'f3'])],
+    ['c4', new Set(['c5'])],
+    ['f4', new Set([])],
+    ['g5', new Set(['g6'])],
+    ['d3', new Set(['d4', 'e4'])]
+  ]);
+  testPosition(
+    fen.read('8/8/8/5RPp/1pP1pP2/3Pp2R/B6B/8 b - - 0 1'),
+    'black',
+    undefined,
+    expectedPremoves,
+    true,
+  );
+});
+
+test('horde no en passant for first to third rank', () => {
+  const expectedPremoves = new Map<cg.Key, Set<cg.Key>>([
+    ['f1', new Set(['f2', 'f3'])],
+    ['g3', new Set(['g4', 'h4'])]
+  ]);
+  testPosition(
+    fen.read('rnbqkbnr/ppppppp1/8/8/8/6Pp/8/5P2 w kq - 0 1'),
+    'black',
+    ['g1', 'g3'],
+    expectedPremoves,
+    true,
+  );
+});

--- a/tests/premove.test.ts
+++ b/tests/premove.test.ts
@@ -99,7 +99,7 @@ test('anticipate all en passant captures if no last move', () => {
     ['c4', new Set(['c5'])],
     ['f4', new Set([])],
     ['g5', new Set(['g6'])],
-    ['d3', new Set(['d4', 'e4'])]
+    ['d3', new Set(['d4', 'e4'])],
   ]);
   testPosition(
     fen.read('8/8/8/5RPp/1pP1pP2/3Pp2R/B6B/8 b - - 0 1'),
@@ -113,7 +113,7 @@ test('anticipate all en passant captures if no last move', () => {
 test('horde no en passant for first to third rank', () => {
   const expectedPremoves = new Map<cg.Key, Set<cg.Key>>([
     ['f1', new Set(['f2', 'f3'])],
-    ['g3', new Set(['g4', 'h4'])]
+    ['g3', new Set(['g4', 'h4'])],
   ]);
   testPosition(
     fen.read('rnbqkbnr/ppppppp1/8/8/8/6Pp/8/5P2 w kq - 0 1'),


### PR DESCRIPTION
- If a pawn has just moved from the 1st rank to the 3rd (i.e., in horde), do not assume (when calculating premoves) that an enemy pawn on the 3rd rank can capture it.
- If there is no lastMove (e.g., when playing from position), assume for premoves that any enemy pawn on the 4th rank can capture a friendly on the same rank.

These edge cases hardly matter, but the code itself is probably a little more proper than it was.