### PR TITLE
Add ranksPosition property to Config interface

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   selected?: cg.Key; // square currently selected "a1"
   coordinates?: boolean; // include coords attributes
   coordinatesOnSquares?: boolean; // include coords attributes on every square
+  ranksPosition: cg.RanksPosition; // position ranks on either side. left | right
   autoCastle?: boolean; // immediately complete the castle by moving the rook after king move
   viewOnly?: boolean; // don't bind events: the user will never be able to move pieces around
   disableContextMenu?: boolean; // because who needs a context menu on a chessboard


### PR DESCRIPTION
This allows the users of the library to configure the position of ranks on the board.