### PR TITLE
reduce pieceCloseTo measurement radius by sqrt(2)

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -86,7 +86,7 @@ export function start(s: State, e: cg.MouchEvent): void {
 function pieceCloseTo(s: State, pos: cg.NumberPair): boolean {
   const asWhite = board.whitePov(s),
     bounds = s.dom.bounds(),
-    radiusSq = Math.pow(bounds.width / 8, 2);
+    radiusSq = Math.pow(bounds.width / 16, 2) * 2;
   for (const key of s.pieces.keys()) {
     const center = util.computeSquareCenter(key, asWhite, bounds);
     if (util.distanceSq(center, pos) <= radiusSq) return true;


### PR DESCRIPTION
this PR lessens the distance from an occupied square at which touchstarts on an unoccupied square are captured and killed. the new distance is a radius drawn from a square's center to its square's corner.

the legacy behavior captures touchstarts at radii beyond the center of surrounding empty squares. this made it impossible to initiate a scroll on many mid-game boards.