### PR TITLE
fix safari arrowhead issue introduced in 9.5.0

### DIFF
--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -89,8 +89,8 @@ function svgContainer(cls: string, isShapes: boolean) {
     viewBox: isShapes ? '-4 -4 8 8' : '-3.5 -3.5 8 8',
     preserveAspectRatio: 'xMidYMid slice',
   });
-  svg.appendChild(createSVG('g'));
   if (isShapes) svg.appendChild(createDefs());
+  svg.appendChild(createSVG('g'));
   return svg;
 }
 


### PR DESCRIPTION
safari does not always handle forward references to <defs> properly. this fix just ensures defs elements occur before any referencing elements in the <svg> container (as was previously the case in chessground 9.4.1 and below)

fix https://github.com/lichess-org/lila/issues/18227