### PR TITLE
Clear shapes patches

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,7 @@ export interface Config {
     defaultSnapToValidMove?: boolean;
     // Clicking an empty square or immovable piece will clear the drawing regardless, but when this property is true,
     // clicking on a (currently unselected) movable piece will also clear the drawing.
-    eraseOnMouchDown?: boolean;
+    eraseOnClick?: boolean;
     shapes?: DrawShape[];
     autoShapes?: DrawShape[];
     brushes?: DrawBrushes;

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -30,7 +30,7 @@ export function start(s: State, e: cg.MouchEvent): void {
   const piece = s.pieces.get(orig);
   const previouslySelected = s.selected;
   if (!previouslySelected && s.drawable.enabled) {
-    if (s.drawable.eraseOnMouchDown) drawClear(s);
+    if (s.drawable.eraseOnClick) drawClear(s);
     else if (piece?.color !== s.turnColor) s.pixelCoordsOfMouchDownToMaybeClearShapes = position;
   }
   // Prevent touch scroll and create no corresponding mouse event, if there

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -44,7 +44,7 @@ export interface Drawable {
   enabled: boolean; // can draw
   visible: boolean; // can view
   defaultSnapToValidMove: boolean;
-  eraseOnMouchDown: boolean;
+  eraseOnClick: boolean;
   onChange?: (shapes: DrawShape[]) => void;
   shapes: DrawShape[]; // user shapes
   autoShapes: DrawShape[]; // computer shapes

--- a/src/state.ts
+++ b/src/state.ts
@@ -177,7 +177,7 @@ export function defaults(): HeadlessState {
       enabled: true, // can draw
       visible: true, // can view
       defaultSnapToValidMove: true,
-      eraseOnMouchDown: true,
+      eraseOnClick: true,
       shapes: [],
       autoShapes: [],
       brushes: {


### PR DESCRIPTION
This PR does the following:
- Renames the 'erase' property (again).
- If said property is true, ensure the behaviour doesn't change. For example, in a live game, a mouchdown anywhere will clear all drawings.
- Otherwise, clear arrows if the user clicks on a non-movable square, and then drags by a distance of at least 15px. This increases the requirement from the original PR, where all drawings would be cleared on any position change.

An outstanding concern of mine is whether clicking off the board and then back on it works properly. From personal experience yesterday, I noticed this was a bit glitchy. E.g., I think I had clicked off the board, and then after trying to click back on it a few times, the ctrl-z function (to clear drawings) didn't work. I'm not sure if anyone has insight into whether this PR would affect this, but just wanted to mention it.

If we merge this, we should probably close all issues made in chessground and lila, so that in case anyone still experiences bugs, they don't feel they'd be making a duplicate issue.