### PR TITLE
Fix castling premove to respect rookCastle preference

### DIFF
--- a/src/premove.ts
+++ b/src/premove.ts
@@ -182,10 +182,13 @@ const king: Mobility = (ctx: MobilityContext) =>
   (ctx.canCastle &&
     ctx.orig.pos[1] === ctx.dest.pos[1] &&
     ctx.orig.pos[1] === (ctx.color === 'white' ? 0 : 7) &&
-    ((ctx.orig.pos[0] === 4 &&
-      ((ctx.dest.pos[0] === 2 && ctx.rookFilesFriendlies.includes(0)) ||
-        (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)))) ||
-      ctx.rookFilesFriendlies.includes(ctx.dest.pos[0])) &&
+    (ctx.rookCastle
+      ? // Rook castling: king moves onto rook
+        ctx.rookFilesFriendlies.includes(ctx.dest.pos[0])
+      : // Standard castling: king moves two squares
+        ctx.orig.pos[0] === 4 &&
+        ((ctx.dest.pos[0] === 2 && ctx.rookFilesFriendlies.includes(0)) ||
+          (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)))) &&
     (ctx.unrestrictedPremoves ||
       /* The following checks if no non-rook friendly piece is in the way between the king and its castling destination.
          Note that for the Chess960 edge case of Kb1 "long castling", the check passes even if there is a piece in the way
@@ -224,6 +227,7 @@ export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
         )
         .map(([k]) => util.key2pos(k)[0]),
       lastMove: state.lastMove,
+      rookCastle: state.movable.rookCastle,
     };
   return util.allPosAndKey.filter(dest => mobility({ ...partialCtx, dest })).map(pk => pk.key);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,7 @@ export type MobilityContext = {
   canCastle: boolean;
   rookFilesFriendlies: number[];
   lastMove: Key[] | undefined;
+  rookCastle: boolean;
 };
 
 export type Mobility = (ctx: MobilityContext) => boolean;


### PR DESCRIPTION
Add rookCastle field to MobilityContext and update king mobility validation to only allow the user's preferred castling method in premoves. This fixes a bug where both castling methods were allowed as premoves, but only the preferred method would execute successfully.

This is for issue https://github.com/lichess-org/lila/issues/18586