### PR TITLE
Update hash when number of angles to dest changes

### DIFF
--- a/src/svg.ts
+++ b/src/svg.ts
@@ -71,14 +71,14 @@ export function renderSvg(state: State, els: cg.Elements): void {
       shape: s,
       current: false,
       pendingErase: isPendingErase,
-      hash: shapeHash(s, isShort(s.dest, dests), false, bounds, isPendingErase),
+      hash: shapeHash(s, isShort(s.dest, dests), false, bounds, isPendingErase, angleCount(s.dest, dests)),
     });
   }
   if (cur && pendingEraseIdx === -1)
     shapes.push({
       shape: cur,
       current: true,
-      hash: shapeHash(cur, isShort(cur.dest, dests), true, bounds, false),
+      hash: shapeHash(cur, isShort(cur.dest, dests), true, bounds, false, angleCount(cur.dest, dests)),
       pendingErase: false,
     });
 
@@ -156,6 +156,7 @@ function shapeHash(
   current: boolean,
   bounds: DOMRectReadOnly,
   pendingErase: boolean,
+  angleCountOfDest: number,
 ): Hash {
   // a shape and an overlay svg share a lifetime and have the same cgHash attribute
   return [
@@ -163,6 +164,7 @@ function shapeHash(
     bounds.height,
     current,
     pendingErase && 'pendingErase',
+    angleCountOfDest,
     orig,
     dest,
     brush,
@@ -357,6 +359,9 @@ function orient(pos: cg.Pos, color: cg.Color): cg.Pos {
 function isShort(dest: cg.Key | undefined, dests: ArrowDests) {
   return true === (dest && dests.has(dest) && dests.get(dest)!.size > 1);
 }
+
+const angleCount = (dest: cg.Key | undefined, dests: ArrowDests): number =>
+  dest && dests.has(dest) ? dests.get(dest)!.size : 0;
 
 function createElement(tagName: string): SVGElement {
   return document.createElementNS('http://www.w3.org/2000/svg', tagName);


### PR DESCRIPTION
The purpose is so that labels always update their position, in cases where there is more than one neighbouring arrow. Definitely an edge case that doesn't really matter, but maybe having the hash store the number of angles could be useful for other things at some point?

Example with a hardcoded label from f6-e4:

Before:

https://github.com/user-attachments/assets/ec2d6892-bc1c-4b7f-a686-6ba06421969f

After:

https://github.com/user-attachments/assets/18c201ce-0fac-4a03-bf73-e291631bae40

The reason this bug exists is because when there's already a neighbouring arrow that's caused the primary arrow to shorten, adding a new neighbour won't change this (which means the hash doesn't change, causing the label to not have its position updated on the primary arrow).