### PR TITLE
Support opt-in multiple premoves

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,7 +16,7 @@ export interface Api {
   // read chessground state; write at your own risks.
   state: State;
 
-  // get the position as a FEN string (only contains pieces, no flags)
+  // get the authoritative position as a FEN string (only contains pieces, no flags)
   // e.g. rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR
   getFen(): cg.FEN;
 
@@ -92,7 +92,10 @@ export function start(state: State, redrawAll: cg.Redraw): Api {
 
     state,
 
-    getFen: () => fenWrite(state.pieces),
+    // Multiple premoves may render a speculative position. Consumers such as
+    // Lila use getFen() to decide whether an incoming server position needs to
+    // be applied, so expose the latest authoritative base rather than the preview.
+    getFen: () => fenWrite(state.premovable.basePieces ?? state.pieces),
 
     toggleOrientation,
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -33,11 +33,19 @@ export function reset(state: HeadlessState): void {
   unsetPredrop(state);
 }
 
-export function setPieces(state: HeadlessState, pieces: cg.PiecesDiff): void {
-  for (const [key, piece] of pieces) {
-    if (piece) state.pieces.set(key, piece);
-    else state.pieces.delete(key);
+function applyPiecesDiff(pieces: cg.Pieces, diff: cg.PiecesDiff): void {
+  for (const [key, piece] of diff) {
+    if (piece) pieces.set(key, piece);
+    else pieces.delete(key);
   }
+}
+
+export function setPieces(state: HeadlessState, pieces: cg.PiecesDiff): void {
+  applyPiecesDiff(state.pieces, pieces);
+  // While a queue preview is active, basePieces is the authoritative board that
+  // will be used to reconstruct the preview. Keep programmatic piece updates
+  // (promotion, en passant, atomic explosions, etc.) in that base as well.
+  if (state.premovable.basePieces) applyPiecesDiff(state.premovable.basePieces, pieces);
 }
 
 export function setCheck(state: HeadlessState, color: cg.Color | boolean): void {
@@ -51,17 +59,86 @@ export function setCheck(state: HeadlessState, color: cg.Color | boolean): void 
     }
 }
 
+const multiplePremovesEnabled = (state: HeadlessState): boolean => state.premovable.maxCount > 1;
+
+function previewMove(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
+  const piece = state.pieces.get(orig);
+  if (!piece || orig === dest) return false;
+  if (!tryAutoCastle(state, orig, dest)) {
+    state.pieces.set(dest, piece);
+    state.pieces.delete(orig);
+  }
+  return true;
+}
+
+function rebuildPremovePreview(state: HeadlessState): boolean {
+  const base = state.premovable.basePieces;
+  if (!base) return false;
+  state.pieces = new Map(base);
+  for (const [orig, dest] of state.premovable.queue) if (!previewMove(state, orig, dest)) return false;
+  return true;
+}
+
+function redrawAfterPreview(state: HeadlessState): void {
+  (state as HeadlessState & { dom?: cg.Dom }).dom?.redraw();
+}
+
+function schedulePremovePreview(state: HeadlessState): void {
+  const pm = state.premovable;
+  const expectedBase = pm.basePieces;
+  const expectedQueue = pm.queue;
+  setTimeout(() => {
+    if (
+      !expectedBase ||
+      pm.basePieces !== expectedBase ||
+      pm.queue !== expectedQueue ||
+      !pm.queue.length ||
+      !multiplePremovesEnabled(state)
+    )
+      return;
+    if (!rebuildPremovePreview(state)) clearPremove(state, true);
+    redrawAfterPreview(state);
+  }, 1);
+}
+
+function clearPremove(state: HeadlessState, restorePreview: boolean): void {
+  const pm = state.premovable;
+  const hadPremove = !!pm.current || pm.queue.length > 0;
+  if (restorePreview && pm.basePieces) state.pieces = new Map(pm.basePieces);
+  pm.current = undefined;
+  pm.queue = [];
+  pm.basePieces = undefined;
+  if (hadPremove) callUserFunction(pm.events.unset);
+}
+
 function setPremove(state: HeadlessState, orig: cg.Key, dest: cg.Key, meta: cg.SetPremoveMetadata): void {
   unsetPredrop(state);
-  state.premovable.current = [orig, dest];
-  callUserFunction(state.premovable.events.set, orig, dest, meta);
+  const pm = state.premovable;
+  const move: cg.KeyPair = [orig, dest];
+
+  // Preserve the existing Chessground semantics by default: a new premove replaces
+  // the previous one and pieces stay on the authoritative board squares.
+  if (!multiplePremovesEnabled(state)) {
+    pm.queue = [move];
+    pm.current = move;
+    callUserFunction(pm.events.set, orig, dest, meta);
+    return;
+  }
+
+  if (pm.queue.length >= pm.maxCount) return;
+  if (!pm.queue.length) pm.basePieces = new Map(state.pieces);
+
+  pm.queue.push(move);
+  pm.current = pm.queue[0];
+  // Keep the long-standing async callback semantics. The speculative board is
+  // rebuilt after the callback tick, so consumers still observe the position in
+  // which this premove was entered (important for pre-promotion detection).
+  callUserFunction(pm.events.set, orig, dest, meta);
+  schedulePremovePreview(state);
 }
 
 export function unsetPremove(state: HeadlessState): void {
-  if (state.premovable.current) {
-    state.premovable.current = undefined;
-    callUserFunction(state.premovable.events.unset);
-  }
+  clearPremove(state, true);
 }
 
 function setPredrop(state: HeadlessState, role: cg.Role, key: cg.Key): void {
@@ -293,7 +370,8 @@ export function isDraggable(state: HeadlessState, orig: cg.Key): boolean {
 }
 
 export function playPremove(state: HeadlessState): boolean {
-  const move = state.premovable.current;
+  const pm = state.premovable;
+  const move = pm.queue[0] ?? pm.current;
   if (!move) return false;
   const orig = move[0],
     dest = move[1];
@@ -307,8 +385,36 @@ export function playPremove(state: HeadlessState): boolean {
       success = true;
     }
   }
-  unsetPremove(state);
-  return success;
+
+  if (!multiplePremovesEnabled(state)) {
+    clearPremove(state, false);
+    return success;
+  }
+
+  if (!success) {
+    // The head no longer matches the real position after the opponent's move.
+    // The rest of the chain depends on it, so discard the complete queue.
+    clearPremove(state, true);
+    return false;
+  }
+
+  pm.queue.shift();
+  pm.current = pm.queue[0];
+  if (!pm.queue.length) {
+    // Match the legacy single-premove contract: consuming the final
+    // premove emits unset after the move callback, while preserving
+    // the already-played authoritative board position.
+    pm.basePieces = undefined;
+    callUserFunction(pm.events.unset);
+    return true;
+  }
+
+  // Keep the just-played move as the new authoritative base. Existing move
+  // callbacks run asynchronously; rebuild the speculative tail after them so
+  // promotion, en passant and atomic callbacks observe the normal post-move board.
+  pm.basePieces = new Map(state.pieces);
+  schedulePremovePreview(state);
+  return true;
 }
 
 export function playPredrop(state: HeadlessState, validate: (drop: cg.Drop) => boolean): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { setCheck, setSelected } from './board.js';
+import { setCheck, setSelected, unsetPremove } from './board.js';
 import { type DrawBrushes, type DrawShape } from './draw.js';
 import { read as fenRead } from './fen.js';
 import { type HeadlessState } from './state.js';
@@ -49,10 +49,11 @@ export interface Config {
     castle?: boolean; // whether to allow king castle premoves
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
+    maxCount?: number; // maximum queued premoves; 1 keeps the legacy single-premove behaviour
     additionalPremoveRequirements?: cg.Mobility;
     events?: {
-      set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
-      unset?: () => void; // called after the premove has been unset
+      set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after a premove has been set
+      unset?: () => void; // called after the premove queue has been cleared
     };
   };
   predroppable?: {
@@ -80,11 +81,11 @@ export interface Config {
     move?: (orig: cg.Key, dest: cg.Key, capturedPiece?: cg.Piece) => void;
     dropNewPiece?: (piece: cg.Piece, key: cg.Key) => void;
     select?: (key: cg.Key) => void; // called when a square is selected
-    insert?: (elements: cg.Elements) => void; // when the board DOM has been (re)inserted
+    insert?: (elements: cg.Elements) => void; // called when the board DOM has been (re)inserted
   };
   drawable?: {
     enabled?: boolean; // can draw
-    visible?: boolean; // can view
+    visible?: boolean;
     defaultSnapToValidMove?: boolean;
     // Clicking an empty square or immovable piece will clear the drawing regardless, but when this property is true,
     // clicking on a (currently unselected) movable piece will also clear the drawing.
@@ -105,6 +106,26 @@ export function applyAnimation(state: HeadlessState, config: Config): void {
 }
 
 export function configure(state: HeadlessState, config: Config): void {
+  // A live preference change must never leave a speculative queue armed behind
+  // a disabled premove setting. Restore the authoritative pieces before applying
+  // the new configuration so a later playPremove() cannot execute stale input.
+  if (config.premovable?.enabled === false && state.premovable.queue.length) unsetPremove(state);
+  // Switching multiple -> single keeps the queue head, cancels the dependent
+  // tail and removes the speculative preview. This mirrors the compatibility
+  // behavior of a legacy single premove rather than silently discarding the head.
+  else if (
+    config.premovable?.maxCount !== undefined &&
+    config.premovable.maxCount <= 1 &&
+    state.premovable.maxCount > 1 &&
+    state.premovable.queue.length
+  ) {
+    const head = state.premovable.queue[0];
+    if (state.premovable.basePieces) state.pieces = new Map(state.premovable.basePieces);
+    state.premovable.queue = [head];
+    state.premovable.current = head;
+    state.premovable.basePieces = undefined;
+  }
+
   // don't merge destinations and autoShapes. Just override.
   if (config.movable?.dests) state.movable.dests = undefined;
   if (config.drawable?.autoShapes) state.drawable.autoShapes = [];
@@ -115,6 +136,11 @@ export function configure(state: HeadlessState, config: Config): void {
   if (config.fen) {
     state.pieces = fenRead(config.fen);
     state.drawable.shapes = config.drawable?.shapes || [];
+    // A server/parent position update becomes the new authoritative base for any
+    // queued premoves. playPremove() will validate the queue head against these
+    // real pieces before rebuilding the speculative preview for the remaining tail.
+    if (state.premovable.maxCount > 1 && state.premovable.queue.length)
+      state.premovable.basePieces = new Map(state.pieces);
   }
 
   // apply config values that could be undefined yet meaningful

--- a/src/state.ts
+++ b/src/state.ts
@@ -52,11 +52,14 @@ export interface HeadlessState {
     castle: boolean; // whether to allow king castle premoves
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
-    current?: cg.KeyPair; // keys of the current saved premove ["e2" "e4"]
+    current?: cg.KeyPair; // head of the saved premove queue, kept for backwards compatibility
+    queue: cg.KeyPair[]; // saved premoves in execution order
+    maxCount: number; // 1 preserves legacy single-premove behaviour; values >1 enable a queue
+    basePieces?: cg.Pieces; // authoritative pieces before applying the speculative queue preview
     additionalPremoveRequirements: cg.Mobility;
     events: {
-      set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
-      unset?: () => void; // called after the premove has been unset
+      set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after a premove has been set
+      unset?: () => void; // called after the premove queue has been cleared
     };
   };
   predroppable: {
@@ -147,6 +150,8 @@ export function defaults(): HeadlessState {
       enabled: true,
       showDests: true,
       castle: true,
+      queue: [],
+      maxCount: 1,
       additionalPremoveRequirements: _ => true,
       events: {},
     },

--- a/tests/multiplePremove.test.ts
+++ b/tests/multiplePremove.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { start } from '../src/api';
+import { playPremove, setPieces, userMove } from '../src/board';
+import { configure } from '../src/config';
+import { defaults, type HeadlessState, type State } from '../src/state';
+import type * as cg from '../src/types';
+
+const position = (whiteKing: cg.Key, blackKing: cg.Key = 'h8'): cg.Pieces =>
+  new Map([
+    [whiteKing, { role: 'king', color: 'white' }],
+    [blackKing, { role: 'king', color: 'black' }],
+  ]);
+
+const makeState = (maxCount: number): HeadlessState => {
+  const state = defaults();
+  state.pieces = position('g2');
+  state.turnColor = 'black';
+  state.movable.color = 'white';
+  state.movable.free = false;
+  state.premovable.maxCount = maxCount;
+  return state;
+};
+
+const flushPreview = (): void => vi.runAllTimers();
+
+const applyAuthoritativePosition = (state: HeadlessState, piecesFen: string, dests: cg.Dests): void => {
+  configure(state, {
+    fen: piecesFen,
+    turnColor: 'white',
+    movable: {
+      color: 'white',
+      free: false,
+      dests,
+    },
+  });
+};
+
+afterEach(() => vi.useRealTimers());
+
+test('single premove mode keeps the legacy non-preview behaviour', () => {
+  const state = makeState(1);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  expect(state.premovable.queue).toEqual([['g2', 'f2']]);
+  expect(state.premovable.current).toEqual(['g2', 'f2']);
+  expect(state.pieces.has('g2')).toBe(true);
+  expect(state.pieces.has('f2')).toBe(false);
+});
+
+test('multiple premoves build a speculative position and execute in order', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  // Preserve the established async callback contract: preview is built after the callback tick.
+  expect(state.pieces.has('g2')).toBe(true);
+  flushPreview();
+  expect(state.pieces.has('f2')).toBe(true);
+
+  expect(userMove(state, 'f2', 'e2')).toBe(true);
+  flushPreview();
+  expect(state.pieces.has('e2')).toBe(true);
+  expect(state.premovable.queue).toEqual([
+    ['g2', 'f2'],
+    ['f2', 'e2'],
+  ]);
+
+  applyAuthoritativePosition(state, '7k/8/8/8/8/8/6K1/8 w - - 0 1', new Map([['g2', ['f2']]]));
+
+  expect(playPremove(state)).toBe(true);
+  expect(state.premovable.queue).toEqual([['f2', 'e2']]);
+  // Callbacks see the normal post-head board before the dependent preview is restored.
+  expect(state.pieces.has('f2')).toBe(true);
+  expect(state.pieces.has('e2')).toBe(false);
+  flushPreview();
+  expect(state.pieces.has('e2')).toBe(true);
+  expect(state.pieces.has('f2')).toBe(false);
+
+  applyAuthoritativePosition(state, '8/7k/8/8/8/8/5K2/8 w - - 0 1', new Map([['f2', ['e2']]]));
+
+  expect(playPremove(state)).toBe(true);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+  expect(state.pieces.has('e2')).toBe(true);
+});
+
+test('getFen reports the authoritative base while a speculative queue is displayed', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+  const api = start(state as State, () => {});
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+
+  expect(state.pieces.has('f2')).toBe(true);
+  expect(api.getFen()).toBe('7k/8/8/8/8/8/6K1/8');
+});
+
+test('an illegal queue head cancels the dependent tail and restores the real position', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+  expect(userMove(state, 'f2', 'e2')).toBe(true);
+  flushPreview();
+
+  applyAuthoritativePosition(state, '8/7k/8/8/8/8/6K1/8 w - - 0 1', new Map([['g2', ['h2']]]));
+
+  expect(playPremove(state)).toBe(false);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+  expect(state.pieces.has('g2')).toBe(true);
+  expect(state.pieces.has('h7')).toBe(true);
+  expect(state.pieces.has('h8')).toBe(false);
+  expect(state.pieces.has('f2')).toBe(false);
+  expect(state.pieces.has('e2')).toBe(false);
+});
+
+test('programmatic piece updates are retained when rebuilding a queued preview', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+  expect(userMove(state, 'f2', 'e2')).toBe(true);
+  flushPreview();
+
+  applyAuthoritativePosition(state, '7k/8/8/8/8/8/6K1/8 w - - 0 1', new Map([['g2', ['f2']]]));
+  expect(playPremove(state)).toBe(true);
+
+  // Models a synchronous downstream board correction performed by an existing
+  // move callback (promotion, en passant or atomic explosion) before preview rebuild.
+  setPieces(state, new Map([['h8', undefined]]));
+  flushPreview();
+
+  expect(state.premovable.basePieces?.has('h8')).toBe(false);
+  expect(state.pieces.has('h8')).toBe(false);
+  expect(state.pieces.has('e2')).toBe(true);
+});
+
+test('disabling premoves clears the queue and restores authoritative pieces', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+  expect(userMove(state, 'f2', 'e2')).toBe(true);
+  flushPreview();
+  expect(state.pieces.has('e2')).toBe(true);
+
+  configure(state, { premovable: { enabled: false } });
+
+  expect(state.premovable.enabled).toBe(false);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+  expect(state.pieces.has('g2')).toBe(true);
+  expect(state.pieces.has('f2')).toBe(false);
+  expect(state.pieces.has('e2')).toBe(false);
+});
+
+test('switching multiple premoves to single keeps only the head without previewing it', () => {
+  vi.useFakeTimers();
+  const state = makeState(4);
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+  expect(userMove(state, 'f2', 'e2')).toBe(true);
+  flushPreview();
+  expect(state.pieces.has('e2')).toBe(true);
+
+  configure(state, { premovable: { maxCount: 1 } });
+
+  expect(state.premovable.maxCount).toBe(1);
+  expect(state.premovable.queue).toEqual([['g2', 'f2']]);
+  expect(state.premovable.current).toEqual(['g2', 'f2']);
+  expect(state.pieces.has('g2')).toBe(true);
+  expect(state.pieces.has('f2')).toBe(false);
+  expect(state.pieces.has('e2')).toBe(false);
+});
+
+test('consuming the last queued premove emits the legacy unset callback', () => {
+  vi.useFakeTimers();
+  const state = makeState(2);
+  const unset = vi.fn();
+  state.premovable.events.unset = unset;
+
+  expect(userMove(state, 'g2', 'f2')).toBe(true);
+  flushPreview();
+  applyAuthoritativePosition(state, '7k/8/8/8/8/8/6K1/8 w - - 0 1', new Map([['g2', ['f2']]]));
+
+  expect(playPremove(state)).toBe(true);
+  expect(state.premovable.queue).toEqual([]);
+  expect(unset).not.toHaveBeenCalled();
+  flushPreview();
+  expect(unset).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary

Add opt-in bounded multiple-premove support to Chessground while preserving the existing single-premove behavior by default.

Related to lichess-org/lila#3890.

## Behavior

- `premovable.maxCount` defaults to `1`, preserving legacy behavior.
- Consumers can opt into a bounded queue by setting `maxCount > 1`.
- Queued moves are shown as a speculative board preview.
- Chessground keeps a separate authoritative base position behind that preview.
- `playPremove()` consumes at most one queue head per authoritative update.
- If the current head is no longer legal, its dependent tail is discarded.
- Returning to single-premove mode keeps only the queue head and removes the speculative preview.

## Compatibility

The existing single-premove API remains compatible.

Chessground does not become authoritative for chess legality. Actual execution still depends on the consumer-provided authoritative `movable.dests`.

Programmatic downstream piece corrections, such as promotion, en passant or variant-specific updates, are retained in the authoritative base before rebuilding a speculative tail.

Consuming the final queued premove also preserves the legacy `premovable.events.unset` callback contract.

## Tests

Regression coverage includes:

- legacy single-premove behavior
- bounded queued premoves
- speculative preview and ordered execution
- authoritative `getFen()` during a preview
- illegal-head invalidation
- programmatic piece updates during tail rebuild
- disabling premoves
- switching multiple → single
- legacy `unset` callback after the final consumed premove

Final clean commit:

`008560e256e1357ff91486bd5c20d2bdb9385ba9`

The complete Chessground GitHub Actions CI matrix passes.

The paired Lila integration has also passed frontend build/tests/lint/format/CodeQL and the full Scala `test;stage` run against this core.

## AI disclosure

OpenAI ChatGPT (GPT-5.6 Sol) assisted with auditing an earlier prototype, separating reusable Chessground behavior from Lila-specific integration, identifying callback and authoritative-state edge cases, preparing regression tests, and validating the final branch.

Representative prompts/directives asked to continue the upstream multiple-premremove implementation, thoroughly test it, preserve legacy single-premove behavior by default, keep authoritative chess legality outside Chessground, and prepare a focused maintainer-ready change.

The submitted diff has been reviewed during preparation; browser-level manual testing of the complete Lila integration is being performed separately.