### PR TITLE
Dont suppress ghosts on click after move 1

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -60,7 +60,7 @@ export function start(s: State, e: cg.MouchEvent): void {
       piece,
       origPos: position,
       pos: position,
-      started: s.draggable.autoDistance && s.stats.dragged,
+      started: s.draggable.autoDistance,
       element,
       previouslySelected,
       originTarget: e.target,


### PR DESCRIPTION
In "Either click or drag to move" mode, the piece immediately snaps to the mouse cursor on click in analysis and puzzles, for all moves. In rounds, the piece only snaps to the mouse cursor on click for the first recorded move. That sets s.stats.dragged to true which suppresses this behavior for the remainder of the game or until reload.

This is purely cosmetic, and people may have grown used to it. But it is inconsistent, the relevant code seems to have a diagnostic purpose, at least from the name, and it's from 9 years back. So it's worth a look.

Personally I would not rock this boat (unless the ghost suppression is an obvious bug). But ideally this ghost-on-click suppression would result from an explicit action by the chessground client rather than a consequence of userMove return value.