### PR TITLE
Feat: Add multi-premove queue and L-shaped knight-move arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ More? Please make a pull request to include it here.
 - [Config types](https://github.com/lichess-org/chessground/tree/master/src/config.ts)
 - [Default config values](https://github.com/lichess-org/chessground/tree/master/src/state.ts)
 - [API type signatures](https://github.com/lichess-org/chessground/tree/master/src/api.ts)
+- [Premoves guide (single & multi-premove queue)](docs/premove.md)
 - [Simple standalone example](https://github.com/lichess-org/chessground/blob/master/demo.html)
 - [Examples repo](https://github.com/lichess-org/chessground-examples/tree/master/src/units)
 - [Base CSS](https://github.com/lichess-org/chessground-examples/blob/master/assets/chessground.css)

--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -271,3 +271,42 @@ cg-board square.premove-queue-7 {
 cg-board square.premove-queue-8 {
   background-color: var(--premove-queue-color-8);
 }
+
+/* Virtual premove pieces layer.
+   - Sits above the authoritative piece layer so the destination shows the
+     moved piece, and below the drag ghost (z-index 11).
+   - pointer-events: none so the layer never blocks the underlying board
+     hit-testing; clicks/drags still target the authoritative nodes. */
+.cg-wrap cg-premove-pieces {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 6;
+}
+
+.cg-wrap cg-premove-pieces piece {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 12.5%;
+  height: 12.5%;
+  background-size: cover;
+  will-change: transform;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+.cg-wrap cg-premove-pieces piece.dragging {
+  z-index: 11 !important;
+}
+
+/* While a virtual piece is rendered at the destination, the corresponding
+   authoritative source node should be hidden visually (it still exists in the
+   DOM for hit-testing on a drag from the original square). The class is
+   toggled on authoritative piece nodes by the premove-pieces renderer. */
+.cg-wrap cg-board piece.premove-source {
+  visibility: hidden;
+}

--- a/assets/chessground.base.css
+++ b/assets/chessground.base.css
@@ -2,6 +2,17 @@
   box-sizing: content-box;
   position: relative;
   display: block;
+  /* Color ramp for a chess.com-style premove queue. Earlier queued moves use a
+     muted red/orange, the most recently queued move uses a brighter yellow-green.
+     Consumers can override these variables to restyle without touching JS. */
+  --premove-queue-color-1: rgba(150, 30, 25, 0.5);
+  --premove-queue-color-2: rgba(180, 65, 25, 0.5);
+  --premove-queue-color-3: rgba(200, 115, 25, 0.5);
+  --premove-queue-color-4: rgba(165, 175, 40, 0.5);
+  --premove-queue-color-5: rgba(140, 195, 50, 0.5);
+  --premove-queue-color-6: rgba(120, 200, 60, 0.5);
+  --premove-queue-color-7: rgba(110, 205, 70, 0.5);
+  --premove-queue-color-8: rgba(100, 210, 80, 0.5);
 }
 
 cg-container {
@@ -233,4 +244,30 @@ piece.fading {
 
 .cg-wrap coords.squares.rank8 {
   transform: translateX(700%);
+}
+
+/** Chess.com-style premove queue highlights (see --premove-queue-color-N vars above) */
+cg-board square.premove-queue-1 {
+  background-color: var(--premove-queue-color-1);
+}
+cg-board square.premove-queue-2 {
+  background-color: var(--premove-queue-color-2);
+}
+cg-board square.premove-queue-3 {
+  background-color: var(--premove-queue-color-3);
+}
+cg-board square.premove-queue-4 {
+  background-color: var(--premove-queue-color-4);
+}
+cg-board square.premove-queue-5 {
+  background-color: var(--premove-queue-color-5);
+}
+cg-board square.premove-queue-6 {
+  background-color: var(--premove-queue-color-6);
+}
+cg-board square.premove-queue-7 {
+  background-color: var(--premove-queue-color-7);
+}
+cg-board square.premove-queue-8 {
+  background-color: var(--premove-queue-color-8);
 }

--- a/assets/chessground.brown.css
+++ b/assets/chessground.brown.css
@@ -62,3 +62,10 @@ coords.squares:nth-of-type(odd) :nth-child(odd),
 coords.squares:nth-of-type(even) :nth-child(even) {
   color: rgba(255, 255, 255, 0.8);
 }
+
+/* // */
+cg-board piece.premove-source { visibility: hidden; }
+cg-board square.premove-queue-1 { background-color: rgba(220, 60, 60, .6); }
+cg-board square.premove-queue-2 { background-color: rgba(60, 120, 220, .6); }
+/* ... تا 8 */
+cg-board square.premove-queue-via { opacity: .7; }

--- a/demo.html
+++ b/demo.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Chessground Demo</title>
+    <title>Chessground Demo — multi-premove queue &amp; knight-move bend</title>
 
     <link rel="stylesheet" type="text/css" href="assets/chessground.base.css" />
     <link rel="stylesheet" type="text/css" href="assets/chessground.brown.css" />
@@ -12,108 +12,182 @@
       body {
         display: flex;
         flex-wrap: wrap;
+        gap: 16px;
+        font-family: system-ui, sans-serif;
       }
-
-      body > div {
+      body > div.board-wrap {
         margin: 10px;
+        max-width: 340px;
       }
-
       .chessground {
-        width: 500px;
-        height: 500px;
+        width: 320px;
+        height: 320px;
       }
-
       cg-board {
         background-color: #bfcfdd;
+      }
+      .label {
+        font-size: 15px;
+        font-weight: 600;
+        margin-bottom: 6px;
+      }
+      .hint {
+        font-size: 12px;
+        color: #555;
+        margin: 6px 0;
+      }
+      button {
+        margin: 4px 4px 0 0;
+        padding: 6px 10px;
+        font-size: 12px;
+      }
+      code {
+        background: #eee;
+        padding: 1px 4px;
+        border-radius: 3px;
       }
     </style>
 
     <script type="module">
       import { Chessground } from './dist/chessground.js';
 
-      Chessground(document.getElementById('board-1'), {});
-      Chessground(document.getElementById('board-2'), {
-        fen: 'r2q2k1/1p6/p2p4/2pN1rp1/N1Pb2Q1/8/PP1B4/R6K b - - 2 25',
-      });
-      Chessground(document.getElementById('board-3'), {
-        drawable: {
-          autoShapes: [
-            {
-              orig: 'a2',
-              dest: 'a6',
-              brush: 'green',
-              label: { text: 'A' },
-              modifiers: {
-                hilite: '#fff',
-              },
-            },
-            {
-              orig: 'b2',
-              dest: 'b6',
-              brush: 'blue',
-              label: { text: 'B' },
-              modifiers: {
-                lineWidth: 6,
-              },
-            },
-            {
-              orig: 'c2',
-              dest: 'c4',
-              brush: 'red',
-              label: { text: 'C' },
-            },
-            {
-              orig: 'd2',
-              dest: 'd3',
-              brush: 'green',
-              label: { text: 'D' },
-            },
-            {
-              orig: 'f1',
-              dest: 'h3',
-              brush: 'blue',
-              label: { text: 'F' },
-            },
-            {
-              orig: 'g1',
-              dest: 'f3',
-              brush: 'yellow',
-              label: { text: 'E' },
-            },
-          ],
+      /* ------------------------------------------------------------------ *
+       * Board 1 — Chess.com-style multi-premove queue
+       * Black is to move; the user (white) may queue a chain of premoves.
+       * ------------------------------------------------------------------ */
+      const mpEl = document.getElementById('board-premove');
+      const mpStatus = document.getElementById('premove-status');
+      const mpGround = Chessground(mpEl, {
+        fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        turnColor: 'black', // black to move → white can premove
+        movable: {
+          color: 'white',
+          free: true, // demo: treat any premove as legal
+          showDests: true,
+        },
+        premovable: {
+          enabled: true,
+          multiple: true, // <-- the opt-in flag
+          maxQueueLength: 5,
+          showDests: true,
+          events: {
+            set: (orig, dest) => updatePremoveStatus(mpGround),
+            unset: () => updatePremoveStatus(mpGround),
+            queueSet: q => updatePremoveStatus(mpGround),
+            queueUnset: () => updatePremoveStatus(mpGround),
+          },
         },
       });
+
+      function updatePremoveStatus(g) {
+        const q = g.state.premovable.queue;
+        mpStatus.textContent = q.length
+          ? 'Queue: ' + q.map(m => `${m.orig}→${m.dest}`).join(', ')
+          : 'Queue empty — drag or click white pieces to queue premoves.';
+      }
+      updatePremoveStatus(mpGround);
+
+      document.getElementById('mp-play-front').addEventListener('click', () => {
+        mpGround.set({ turnColor: 'white' }); // make it the user's turn
+        const ok = mpGround.playPremove(); // plays (and pops) the front item
+        mpGround.set({ turnColor: 'black' }); // back to opponent's turn for more premoves
+        updatePremoveStatus(mpGround);
+        mpStatus.textContent =
+          (ok ? 'Played a premove. ' : 'Front premove was illegal — queue cleared. ') + mpStatus.textContent;
+      });
+      document.getElementById('mp-pop-last').addEventListener('click', () => {
+        mpGround.popLastPremove();
+        updatePremoveStatus(mpGround);
+      });
+      document.getElementById('mp-clear').addEventListener('click', () => {
+        mpGround.cancelPremoveQueue();
+        updatePremoveStatus(mpGround);
+      });
+
+      /* ------------------------------------------------------------------ *
+       * Board 2 — L-shaped (bent) knight-move arrows
+       * drawable.knightMoveBend: true → knight arrows become a right-angle L.
+       * Right-click drag any shape to draw; knight moves bend.
+       * ------------------------------------------------------------------ */
+      const kbEl = document.getElementById('board-knightbend');
+      const knightShapes = [
+        { orig: 'g1', dest: 'f3', brush: 'green' },
+        { orig: 'b1', dest: 'c3', brush: 'blue' },
+        { orig: 'e2', dest: 'e4', brush: 'yellow' }, // not a knight move → stays straight
+        { orig: 'd1', dest: 'h5', brush: 'red' }, // not a knight move → stays straight
+        { orig: 'f1', dest: 'h3', brush: 'pink' },
+        { orig: 'c1', dest: 'e3', brush: 'purple' },
+      ];
+      const kbGround = Chessground(kbEl, {
+        drawable: {
+          enabled: true,
+          knightMoveBend: true, // <-- the opt-in flag
+          autoShapes: knightShapes,
+        },
+      });
+
+      const kbStatus = document.getElementById('knightbend-status');
+      kbStatus.textContent =
+        'Knight arrows: pink (f1→h3), purple (c1→e3), green (g1→f3), blue (b1→c3) are bent. ' +
+        'Yellow (e2→e4) and red (d1→h5) stay straight. Right-click to draw your own; knight moves bend.';
+
+      const kbToggle = document.getElementById('kb-toggle');
+      kbToggle.textContent = `knightMoveBend: ${kbGround.state.drawable.knightMoveBend}`;
+      kbToggle.addEventListener('click', () => {
+        const next = !kbGround.state.drawable.knightMoveBend;
+        kbGround.set({ drawable: { knightMoveBend: next, autoShapes: knightShapes } });
+        kbToggle.textContent = `knightMoveBend: ${next}`;
+      });
+
+      /* Two extra boards mirroring the existing demo: */
+      Chessground(document.getElementById('board-1'), {});
       Chessground(document.getElementById('board-4'), {
         orientation: 'black',
         coordinatesOnSquares: true,
         ranksPosition: 'left',
       });
-      Chessground(document.getElementById('board-5'), {
-        orientation: 'white',
-        coordinatesOnSquares: true,
-      });
     </script>
   </head>
   <body>
-    <div>
-      basic board, default config
+    <div class="board-wrap">
+      <div class="label">1) Multi-premove queue</div>
+      <div class="hint">
+        Black is to move, so you (white) can queue a <b>chain</b> of premoves. Click or drag a white piece to
+        a square to queue item 1, then another piece for item 2, etc. Each item is validated on a hypothetical
+        board (earlier queued moves already applied). The most recently queued move is the brightest
+        (yellow-green); earlier ones are muted red/orange.
+      </div>
+      <div class="chessground" id="board-premove"></div>
+      <div>
+        <button id="mp-play-front">▶ Play front premove</button>
+        <button id="mp-pop-last">▣ Pop last</button>
+        <button id="mp-clear">✕ Clear queue</button>
+      </div>
+      <div class="hint" id="premove-status"></div>
+    </div>
+
+    <div class="board-wrap">
+      <div class="label">2) L-shaped knight-move arrows</div>
+      <div class="hint">
+        <code>drawable.knightMoveBend</code> is on. Arrows whose origin/destination are a knight's move apart
+        are drawn as a two-segment right angle (origin → pivot → dest) with the arrowhead on the final leg.
+        Non-knight arrows stay straight.
+      </div>
+      <div class="chessground" id="board-knightbend"></div>
+      <div>
+        <button id="kb-toggle">knightMoveBend: true</button>
+      </div>
+      <div class="hint" id="knightbend-status"></div>
+    </div>
+
+    <div class="board-wrap">
+      <div class="label">Basic board, default config</div>
       <div class="chessground" id="board-1"></div>
     </div>
-    <div>
-      board with a fen
-      <div class="chessground" id="board-2"></div>
-    </div>
-    <div>
-      board with fixed arrows + labels
-      <div class="chessground" id="board-3"></div>
-    </div>
-    <div>
-      board with coordinates on-square, ranks position left
+
+    <div class="board-wrap">
+      <div class="label">Board with coordinates on-square, ranks left</div>
       <div class="chessground" id="board-4"></div>
-    </div>
-    <div>
-      board with coordinates on-square
-      <div class="chessground" id="board-5"></div>
     </div>
   </body>
 </html>

--- a/docs/premove.md
+++ b/docs/premove.md
@@ -1,0 +1,319 @@
+# Premoves
+
+Chessground lets a player queue a move **before their turn** ("premove"), so that
+when it becomes their turn the stored move is played automatically. This document
+covers both the classic single-premove behavior and the chess.com-style
+multi-premove queue.
+
+> What "today" is: Chessground has no chess rules of its own. It only knows which
+> squares are selectable and which destination squares to highlight. **Legality is
+> always decided by your game's rules engine**, which you feed in through
+> `movable.dests` (and `movable.color`) and which you honour when you call
+> `playPremove()`.
+
+---
+
+## TL;DR
+
+```ts
+import { Chessground } from '@lichess-org/chessground';
+
+const ground = Chessground(document.body, {
+  fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2',
+  turnColor: 'black',
+  movable: {
+    color: 'white', // the color the user is allowed to premove with
+    // your rules engine's legal moves for the side to move (filled in by you):
+    dests: new Map(),
+  },
+  premovable: {
+    enabled: true, // allow premoves while it is black's turn
+    multiple: true, // chess.com-style queue (default is false)
+    maxQueueLength: 5,
+    showDests: true,
+    events: {
+      set: (orig, dest) => console.log('queued', orig, dest),
+      unset: () => console.log('premove cleared'),
+      queueSet: queue => console.log('queue now', queue),
+      queueUnset: () => console.log('queue emptied'),
+    },
+  },
+});
+
+// When your rules engine reports that the opponent moved and it is now white's
+// turn, attempt to play the queued premove:
+const played = ground.playPremove();
+```
+
+---
+
+## How premoves work
+
+A premove is only possible when **the piece's color is not the side to move**.
+
+| Internal flag        | Meaning                                                                     |
+| -------------------- | --------------------------------------------------------------------------- |
+| `movable.color`      | which color the user may move / premove (`'white'`, `'black'`, or `'both'`) |
+| `turnColor`          | the side actually to move (set by the host app)                             |
+| `premovable.enabled` | master switch for premoves                                                  |
+
+So with `turnColor: 'black'` and `movable.color: 'white'`, the user (white) can
+select a white piece and place it on a destination. Chessground stores that as a
+premove and shows it (as the `current-premove` highlight, or the multi-square
+queue highlight). When the host later sets `turnColor` to white and calls
+`playPremove()`, the move is validated against `movable.dests` and, if legal,
+played for real.
+
+Chessground decides **which destination squares to offer** for a premove by
+calling `premove()` in `src/premove.ts`. That function implements standard piece
+mobility **ignoring check, pins, and occupancy** (it does not even know the real
+rules). It is only a hint for highlighting; the source of truth for "can this
+premove actually happen" is your rules engine.
+
+---
+
+## Configuration (`premovable`)
+
+| Option                          | Type                              | Default     | Description                                                                        |
+| ------------------------------- | --------------------------------- | ----------- | ---------------------------------------------------------------------------------- |
+| `enabled`                       | `boolean`                         | `true`      | Master switch. If `false`, no premoves can be made.                                |
+| `showDests`                     | `boolean`                         | `true`      | Add the `premove-dest` class to highlighted destination squares.                   |
+| `castle`                        | `boolean`                         | `true`      | Allow king-castle premoves (treated as an ordinary king move with the rook).       |
+| `dests`                         | `cg.Key[]`                        | —           | Premove destinations for the currently selected square. Normally computed for you. |
+| `customDests`                   | `cg.Dests`                        | —           | Supply your own premove destinations per origin, overriding the built-in mobility. |
+| `multiple`                      | `boolean`                         | `false`     | Enable the chess.com-style multi-premove queue.                                    |
+| `maxQueueLength`                | `number`                          | `5`         | Maximum number of queued premoves (only when `multiple` is `true`).                |
+| `additionalPremoveRequirements` | `cg.Mobility`                     | `_ => true` | Extra predicate that can veto a destination (`false` excludes it).                 |
+| `events.set`                    | `(orig, dest, metadata?) => void` | —           | Called after a premove is set / queued.                                            |
+| `events.unset`                  | `() => void`                      | —           | Called after the current premove is cleared, or the queue empties.                 |
+| `events.queueSet`               | `(queue) => void`                 | —           | Called whenever the queue content changes (only `multiple`).                       |
+| `events.queueUnset`             | `() => void`                      | —           | Called when the queue becomes empty (only `multiple`).                             |
+
+Both `movable.color` and `movable.dests` are set on the `movable` option, not on
+`premovable`. `premovable` only configures the premove behavior itself.
+
+---
+
+## The premove API
+
+You get these methods back from `Chessground()`:
+
+| Method                 | Behavior (single mode)                                                         | Behavior (`multiple` mode)                                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `playPremove()`        | Plays the stored `current` premove; returns `true` if it was legal and played. | Plays the **front** of the queue and pops it. Returns `true` if legal. If the front is **illegal**, clears the **entire** queue and returns `false`. |
+| `cancelPremove()`      | Clears the current premove.                                                    | Pops the **front** queued item (operates on the front).                                                                                              |
+| `cancelPremoveQueue()` | Same as `cancelPremove()`.                                                     | Clears the **entire** queue.                                                                                                                         |
+| `popLastPremove()`     | Same as `cancelPremove()`.                                                     | Removes the **last** queued item (e.g. for a "right-click / Escape removes last" UX).                                                                |
+
+### `playPremove()` details
+
+- Only **one** real move happens per turn — the queue never "cascades" several
+  moves at once.
+- If the front item is legal, it is played via the same code path as a normal
+  move and its `movable.events.after` fires with `{ premove: true }`.
+- If the front item is illegal (the opponent's actual move invalidated it), the
+  whole remaining queue is cleared — a broken chain does **not** skip ahead.
+
+```ts
+// the loop a typical lichess-like host uses:
+// after the server sends the new position and it is the user's turn:
+ground.set({ turnColor: 'white', movable: { color: 'white', dests: legalMoves } });
+if (!ground.playPremove()) {
+  // the queued move was illegal; the queue has been cleared for you.
+}
+```
+
+---
+
+## Single-premove mode (default, `multiple: false`)
+
+This is the original chessground behavior and is **unchanged**.
+
+- Only one premove can be queued at a time.
+- Setting a new premove **replaces** the old one.
+- When it becomes your turn, `playPremove()` plays that single move.
+- `current` (a `[orig, dest]` pair) reflects the stored premove.
+
+```ts
+const ground = Chessground(el, {
+  turnColor: 'black',
+  movable: { color: 'white', dests: new Map() },
+  premovable: {
+    enabled: true,
+    events: {
+      set: (orig, dest) => console.log('premove set:', orig, dest),
+      unset: () => console.log('premove cleared'),
+    },
+  },
+});
+```
+
+While it is black's turn, white's user selects a white piece and a destination;
+chessground stores `current = ['e2', 'e4']` and highlights both squares with the
+`current-premove` class.
+
+---
+
+## Multi-premove queue mode (`multiple: true`)
+
+This lets the user queue a **chain** of premoves, chess.com-style.
+
+### How the queue is built
+
+1. While it is not the user's turn, they drag / click a piece to a square. That
+   becomes queue item #1.
+2. Still before the opponent has moved, they can queue another piece (or even the
+   same piece, by selecting the square it will be on after item #1). That becomes
+   item #2, and so on, up to `maxQueueLength`.
+3. Each subsequent item is computed against a **hypothetical board** — the real
+   board with items `1..N-1` already applied (captures remove pieces, the moved
+   piece is relocated). This is handled by `premovePieces()` / `applyMoveToPieces()`
+   in `src/premove.ts`.
+
+```ts
+const ground = Chessground(el, {
+  turnColor: 'black',
+  movable: { color: 'white', dests: new Map() },
+  premovable: {
+    multiple: true,
+    maxQueueLength: 5,
+  },
+});
+```
+
+If the user queues `e2→e4` then `g1→f3`, the board shows both moves highlighted
+simultaneously with an **ordinal color ramp** (`premove-queue-1`, `premove-queue-2`,
+…). The most recently queued move uses the brightest (yellow-green) tone and the
+earliest uses a muted red/orange. You can restyle these via the CSS variables
+`--premove-queue-color-1` … `--premove-queue-color-8` without touching JS.
+
+### Queue rules and edge cases
+
+| Behavior                      | Rule                                                                                                                                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Hypothetical board**        | Item _N_ is legal-checked against the board after items `1..N-1` are applied.                                                                                                                    |
+| **Same piece in a chain**     | You can continue moving a piece that was itself the destination of an earlier queued move (select its hypothetical square, then the next square).                                                |
+| **Re-queueing an origin**     | Queueing a move whose origin already appears as an origin of an earlier item **replaces** that item and everything queued after it (later items were computed assuming the piece was elsewhere). |
+| **Empty hypothetical origin** | You cannot start a drag/selection from a square that has no piece on the hypothetical board.                                                                                                     |
+| **Max length**                | The queue is capped at `maxQueueLength`; queueing beyond it is ignored.                                                                                                                          |
+| **Illegal front**             | If `playPremove()`'s front move is illegal after the opponent moves, the **whole queue** is cleared.                                                                                             |
+
+### Execution flow
+
+1. The opponent moves and it becomes the user's real turn (host updates
+   `turnColor`/`movable.dests`).
+2. Host calls `ground.playPremove()`.
+3. The **front** item is validated by your rules engine (`canMove` → `movable.dests`).
+4. If legal → it is played, removed from the front, and the rest of the queue stays
+   for the next cycle. Only that one move happens.
+5. If illegal → the entire queue is cleared.
+
+```ts
+ground.playPremove();
+// After the opponent moves again, ground.playPremove() will attempt the next queued item.
+```
+
+---
+
+## Reading premove state
+
+The `state.premovable` object (exposed as `ground.state.premovable`) is the live
+state:
+
+```ts
+interface PremovableState {
+  enabled: boolean;
+  showDests: boolean;
+  castle: boolean;
+  dests?: cg.Key[]; // destinations for the currently selected square
+  customDests?: cg.Dests;
+  current?: cg.KeyPair; // single-premove: ["e2","e4"]; in multiple mode = front of queue
+  multiple: boolean;
+  maxQueueLength: number;
+  queue: cg.Premove[]; // [{ orig: 'e2', dest: 'e4' }, ...] (multiple mode)
+  additionalPremoveRequirements: cg.Mobility;
+  events: {
+    set?: (orig, dest, meta?) => void;
+    unset?: () => void;
+    queueSet?: (queue) => void;
+    queueUnset?: () => void;
+  };
+}
+```
+
+- In single mode, use `state.premovable.current`.
+- In multiple mode, prefer `state.premovable.queue`; `current` mirrors the front
+  item for backwards compatibility of existing consumers.
+
+> Writing to `queue` directly is possible but bypasses the event/truncation
+> logic; prefer the `ground.*` API methods.
+
+---
+
+## Example: a full premove "opponent moved" handler
+
+```ts
+import { Chessground } from '@lichess-org/chessground';
+
+const ground = Chessground(document.querySelector('#board')!, {
+  turnColor: 'black',
+  coordinates: true,
+  movable: {
+    color: 'white',
+    dests: new Map(), // filled in by host on every turn change
+  },
+  premovable: {
+    enabled: true,
+    multiple: true,
+    maxQueueLength: 3,
+    showDests: true,
+    events: {
+      set: (orig, dest) => {
+        // highlight/queue-feedback lives in the board itself; use this for app state
+        console.log('queued', orig, dest);
+      },
+      queueSet: queue => console.log('queue', queue),
+      unset: () => console.log('premove cleared'),
+      queueUnset: () => console.log('queue emptied'),
+    },
+  },
+});
+
+function onOpponentMove(newFen: string, legalMoves: Map<string, string[]>) {
+  ground.set({
+    fen: newFen,
+    turnColor: 'white',
+    movable: { color: 'white', dests: toCgDests(legalMoves) },
+  });
+
+  // Try to fire the queued premove. Returns false and clears the queue if illegal.
+  const played = ground.playPremove();
+  if (played) console.log('premove played!');
+}
+```
+
+---
+
+## Custom premove destinations
+
+If chessground's built-in mobility is not what you want (you prefer to compute
+destinations yourself), set `premovable.customDests` and/or
+`premovable.additionalPremoveRequirements`:
+
+```ts
+premovable: {
+  enabled: true,
+  customDests: new Map([['e2', ['e4', 'e3']]]),   // exact destinations for a square
+  additionalPremoveRequirements: ctx => ctx.dest.pos[0] > 2, // extra veto
+}
+```
+
+---
+
+## Note: premoves and the real rules engine
+
+Chessground never decides whether a premove is legal in the rules sense — that is
+the host's job via `movable.dests`. The pieces on the real board are **never moved**
+while premoves are only queued; only square highlights change. The actual piece
+rendering reflects the true board until a queued move is played for real with
+`playPremove()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3085 @@
+{
+  "name": "@lichess-org/chessground",
+  "version": "10.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lichess-org/chessground",
+      "version": "10.1.1",
+      "license": "GPL-3.0-or-later",
+      "devDependencies": {
+        "esbuild": "^0.28.1",
+        "jsdom": "^26.1.0",
+        "oxfmt": "^0.57.0",
+        "oxlint": "^1.72.0",
+        "oxlint-tsgolint": "^0.24.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.6"
+      },
+      "engines": {
+        "node": ">=22",
+        "pnpm": "11"
+      },
+      "funding": {
+        "url": "https://lichess.org/patron"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.57.0.tgz",
+      "integrity": "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.57.0.tgz",
+      "integrity": "sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.57.0.tgz",
+      "integrity": "sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.57.0.tgz",
+      "integrity": "sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.57.0.tgz",
+      "integrity": "sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.57.0.tgz",
+      "integrity": "sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.57.0.tgz",
+      "integrity": "sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.57.0.tgz",
+      "integrity": "sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.57.0.tgz",
+      "integrity": "sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.57.0.tgz",
+      "integrity": "sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.57.0.tgz",
+      "integrity": "sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.57.0.tgz",
+      "integrity": "sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.57.0.tgz",
+      "integrity": "sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.57.0.tgz",
+      "integrity": "sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.57.0.tgz",
+      "integrity": "sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.57.0.tgz",
+      "integrity": "sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.57.0.tgz",
+      "integrity": "sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.57.0.tgz",
+      "integrity": "sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.57.0.tgz",
+      "integrity": "sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint-tsgolint/darwin-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+      "integrity": "sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/darwin-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.24.0.tgz",
+      "integrity": "sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.24.0.tgz",
+      "integrity": "sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.24.0.tgz",
+      "integrity": "sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.24.0.tgz",
+      "integrity": "sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.24.0.tgz",
+      "integrity": "sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.81.0.tgz",
+      "integrity": "sha512-IcCRsXiedJoJopY6mpZUBEeVFsUrutmrG7dZ87zMuKJlhg70Ora9bBl1WcCxZQtyI10YpnVdEso5oCg7YcfSHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.81.0.tgz",
+      "integrity": "sha512-GRrIPyTGVhx3L3h+0T5xT2A0jFAcdPv4+IfuXpGDLIdl6XeYhgg/zw72A5ILZoUgRqZuM8F1y+V/gfDriXSxzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.81.0.tgz",
+      "integrity": "sha512-qNQ9tXRgLuKbqSV1S2h9h4KPHjbovO7RRR2/enUOtHzTkFZ7B9X5zqqHJua8dRyc7dBy7Aoyq5pqTSLFVcAzGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.81.0.tgz",
+      "integrity": "sha512-q0QTm32jWga2Gv4j7IaVZN0jYMi9UV73sWVgFtDA4iIfqwMCLLZ3ve+9KwfYtsaKZSgQhmPaogeZWqDZpcY1Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.81.0.tgz",
+      "integrity": "sha512-/+8wVWDXEC7wHVAhOc59Fw/SkMc1arLkFD8iQCaSsmzenK1X4doFqquL9H1wrtGUzaiycVqkf/sSpcILK6W1UA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.81.0.tgz",
+      "integrity": "sha512-4xt422FEgioRq9hAL4Tq7fujGUWnc8z1BJ+Oi8RN8vB8axaP+sdK6a2xdlcQCCYnJg9QMuMFS0AucuIFx/EacA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.81.0.tgz",
+      "integrity": "sha512-u3vna8KdGplH4DRCW9K54D68fcMo7IxVrkCJWwXnIhwtBdnDnYrmzOUA/XjmBlPpcLsgw9Z5BNdY4za9+Dj+MQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.81.0.tgz",
+      "integrity": "sha512-3j9k+gsYsE7nv71GWotXsqsa2l9/aJenD7dVHNt/CBvsb0SgRjSMnHFeP59IXUAl1wvVFhqGl2wJNMwWU3UBlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.81.0.tgz",
+      "integrity": "sha512-k5iAp3dNxW0/uDCBY+WSm8jKB2szu7SkEQZdgRRpDXvuDd69vvDcqhB3A/pWCfCwXyenjNjFn9Td1fVoyAc+Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.81.0.tgz",
+      "integrity": "sha512-TFqLja3uYmVSte6nof9GWrex9Z8WgdZrNiLC6Te5rXGDqXB2y4j/26iFhwosXiAFqDhE9JJVuuCkDKLwptTn1g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.81.0.tgz",
+      "integrity": "sha512-UEcySvGS0NOVo7h7n7CYyJL9+6gFAh7Zc/ToDXVScFvzHSTIxtzkMVU30rmQ6+nQ1LF+UdiRDdJajpDu+OylLg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.81.0.tgz",
+      "integrity": "sha512-H+diDbhD00+wI1IRP8Kz88x/lat+DgtoBJzoTthS16xkTJGNaEkfb8gzmd1rzc/2uDQQMl7GNl+JFUacVeWxIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.81.0.tgz",
+      "integrity": "sha512-8znJ/5TekjOKg1j1Acho4PJMdiAHLtlcXuWEiipOhAMV6rQcXdmDdXCbheyDczN6TjBwiNfjcP81k4AthrKRzw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.81.0.tgz",
+      "integrity": "sha512-Q2Wj70yFsvn5QjlmifFzbj4H+kJy53bwqc41o1fzoM7MpLV1NIbhg/LpWXRfC6KOkSAdUx1Wd8VJsdPmhp/HRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.81.0.tgz",
+      "integrity": "sha512-cPInHp/ddEe5qkyK2IiyQ8Q3Mp2oLLEhhsGgTK2oZx4L6+llGam1H1yBvJZ7qHfOXj8N3hxBS8sj4tO+gtFlIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.81.0.tgz",
+      "integrity": "sha512-0CQxSX4ajqm07AHBf5U33qQzXKdd7wtq/oTL/7vpY6RNNuxrRi8W4bqUV1Jyu/vj+9KmxQyDhxfeVX1nQL6kfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.81.0.tgz",
+      "integrity": "sha512-l0hbeISm9673hVrrQU8j/p2M7YH9Ouoj7p7E/QM55NTrKVLP+P3PF8hLu+OY+x0VtGRW+ggiQKZqmdYps9H+TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.81.0.tgz",
+      "integrity": "sha512-ksqPP5jbFXcYreEQ7zdJh06rJQBymCTyGRCdaXjfcf2aG4f8KxUWY5wcgYHmaTK+FJ4bPG5sUAdOX+6trnH1JA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.81.0.tgz",
+      "integrity": "sha512-IZuUCwGw9emG5JtCp+fYGB+Z4OWEoeEcM8R5BA1pYw63/ieYFVdcU2ylxTpHbVHSenZnsYE+ZZ20uHAJszQ4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oxfmt": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.57.0.tgz",
+      "integrity": "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.57.0",
+        "@oxfmt/binding-android-arm64": "0.57.0",
+        "@oxfmt/binding-darwin-arm64": "0.57.0",
+        "@oxfmt/binding-darwin-x64": "0.57.0",
+        "@oxfmt/binding-freebsd-x64": "0.57.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.57.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.57.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.57.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.57.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.57.0",
+        "@oxfmt/binding-linux-x64-musl": "0.57.0",
+        "@oxfmt/binding-openharmony-arm64": "0.57.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.57.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.57.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.57.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.81.0.tgz",
+      "integrity": "sha512-HyrJYqeoOCL0iqaLEzGewGT48ZX99P3hxYh8udAF9RGGIghSamkXE4ClUyBpEDNqasamThgmlPbuMOe7SAZmHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.81.0",
+        "@oxlint/binding-android-arm64": "1.81.0",
+        "@oxlint/binding-darwin-arm64": "1.81.0",
+        "@oxlint/binding-darwin-x64": "1.81.0",
+        "@oxlint/binding-freebsd-x64": "1.81.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.81.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.81.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.81.0",
+        "@oxlint/binding-linux-arm64-musl": "1.81.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.81.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.81.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.81.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.81.0",
+        "@oxlint/binding-linux-x64-gnu": "1.81.0",
+        "@oxlint/binding-linux-x64-musl": "1.81.0",
+        "@oxlint/binding-openharmony-arm64": "1.81.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.81.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.81.0",
+        "@oxlint/binding-win32-x64-msvc": "1.81.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-tsgolint": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.24.0.tgz",
+      "integrity": "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsgolint": "bin/tsgolint.js"
+      },
+      "optionalDependencies": {
+        "@oxlint-tsgolint/darwin-arm64": "0.24.0",
+        "@oxlint-tsgolint/darwin-x64": "0.24.0",
+        "@oxlint-tsgolint/linux-arm64": "0.24.0",
+        "@oxlint-tsgolint/linux-x64": "0.24.0",
+        "@oxlint-tsgolint/win32-arm64": "0.24.0",
+        "@oxlint-tsgolint/win32-x64": "0.24.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "vitest": "^3.2.6"
   },
   "scripts": {
-    "prepare": "$npm_execpath run compile",
+    "prepare": "npm run compile",
     "compile": "tsc --sourceMap --declaration",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",
     "check-format": "oxfmt --check",
     "bundle": "esbuild src/chessground.ts --bundle --format=esm --outfile=dist/chessground.min.js --minify",
-    "dist": "$npm_execpath run compile && $npm_execpath run bundle",
+    "dist": "npm run compile && npm run bundle",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "vitest": "^3.2.6"
   },
   "scripts": {
-    "prepare": "npm run compile",
+    "prepare": "$npm_execpath run compile",
     "compile": "tsc --sourceMap --declaration",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",
     "check-format": "oxfmt --check",
     "bundle": "esbuild src/chessground.ts --bundle --format=esm --outfile=dist/chessground.min.js --minify",
-    "dist": "npm run compile && npm run bundle",
+    "dist": "$npm_execpath run compile && $npm_execpath run bundle",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/api.ts
+++ b/src/api.ts
@@ -123,6 +123,16 @@ export function start(state: State, redrawAll: cg.Redraw): Api {
     },
 
     playPremove(): boolean {
+      // In queue (multiple) mode, only the front premove can be played, and only
+      // when there's actually something in the queue. The internal `current` may
+      // be stale during config transitions, so we gate on the queue length
+      // rather than `current` here.
+      if (state.premovable.multiple) {
+        if (!state.premovable.queue.length) return false;
+        if (anim(board.playPremove, state)) return true;
+        state.dom.redraw();
+        return false;
+      }
       if (state.premovable.current) {
         if (anim(board.playPremove, state)) return true;
         // if the premove couldn't be played, redraw to clear it up

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,8 +38,14 @@ export interface Api {
   // play the current premove, if any; returns true if premove was played
   playPremove(): boolean;
 
-  // cancel the current premove, if any
+  // cancel the current (front-of-queue) premove, if any
   cancelPremove(): void;
+
+  // cancel the whole premove queue, if any
+  cancelPremoveQueue(): void;
+
+  // remove the last item from the premove queue, if any
+  popLastPremove(): void;
 
   // play the current predrop, if any; returns true if premove was played
   playPredrop(validate: (drop: cg.Drop) => boolean): boolean;
@@ -135,7 +141,18 @@ export function start(state: State, redrawAll: cg.Redraw): Api {
     },
 
     cancelPremove(): void {
-      render(board.unsetPremove, state);
+      render(
+        state => (state.premovable.multiple ? board.cancelPremoveFront(state) : board.unsetPremove(state)),
+        state,
+      );
+    },
+
+    cancelPremoveQueue(): void {
+      render(board.unsetPremoveQueue, state);
+    },
+
+    popLastPremove(): void {
+      render(board.popLastPremove, state);
     },
 
     cancelPredrop(): void {

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,4 +1,4 @@
-import { premove, premovePieces } from './premove.js';
+import { applyMoveToPieces, premove, premovePieces } from './premove.js';
 import { type HeadlessState } from './state.js';
 import type * as cg from './types.js';
 import {
@@ -61,26 +61,79 @@ function setPremove(state: HeadlessState, orig: cg.Key, dest: cg.Key, meta: cg.S
   callUserFunction(state.premovable.events.set, orig, dest, meta);
 }
 
-function addToPremoveQueue(state: HeadlessState, orig: cg.Key, dest: cg.Key): void {
+function addToPremoveQueue(
+  state: HeadlessState,
+  orig: cg.Key,
+  dest: cg.Key,
+  promotion?: cg.Role,
+  reroute?: boolean,
+): void {
   const queue = state.premovable.queue;
   // Re-queueing a move that starts from an origin already used by an earlier
   // queued item invalidates that item and everything queued after it (they were
   // computed on a board where that piece was elsewhere), so truncate from there.
-  const idx = queue.findIndex(item => item.orig === orig);
-  if (idx !== -1) queue.length = idx;
-  // Respect the maximum queue length.
-  if (queue.length >= state.premovable.maxQueueLength) {
-    syncCurrentFromQueue(state);
-    return;
+  // Drag from a virtual destination (reroute=true) additionally lets the
+  // caller re-route by clicking a square the queue has previously placed a
+  // piece on.
+  let idx = queue.findIndex(item => item.orig === orig);
+  if (idx === -1 && reroute && !state.pieces.has(orig)) {
+    let live: cg.Pieces = state.pieces;
+    for (let i = 0; i < queue.length; i++) {
+      const item = queue[i];
+      if (!live.has(item.orig)) break;
+      const before = live;
+      live = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
+      if (live.has(orig) && before !== live) {
+        idx = i;
+        break;
+      }
+    }
   }
-  queue.push({ orig, dest });
+  if (idx !== -1) {
+    if (reroute && queue[idx].orig !== orig) {
+      // The drag started on a square that only holds a piece on the virtual
+      // board — the destination of an earlier queued item. Keep that item's
+      // true origin and retarget its destination instead of orphaning the
+      // piece (nothing would ever move it onto `orig`). Items queued after it
+      // were computed against the old destination and are dropped.
+      const replacement = { orig: queue[idx].orig, dest, ...(promotion ? { promotion } : {}) };
+      queue.length = idx;
+      queue.push(replacement);
+    } else {
+      // Re-queueing from an origin already used by an earlier item replaces
+      // that item and everything queued after it.
+      queue.length = idx;
+      queue.push(promotion ? { orig, dest, promotion } : { orig, dest });
+    }
+  } else {
+    // Respect the maximum queue length (normalised to at least 1).
+    const cap = Math.max(1, state.premovable.maxQueueLength | 0);
+    if (queue.length >= cap) {
+      syncCurrentFromQueue(state);
+      return;
+    }
+    queue.push(promotion ? { orig, dest, promotion } : { orig, dest });
+  }
   syncCurrentFromQueue(state);
-  callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
+  emitQueueSet(state);
 }
 
 function syncCurrentFromQueue(state: HeadlessState): void {
   const front = state.premovable.queue[0];
   state.premovable.current = front ? [front.orig, front.dest] : undefined;
+}
+
+// Emit queueSet with an immutable shallow copy so React-style consumers can't
+// observe internal array mutation.
+function emitQueueSet(state: HeadlessState): void {
+  const ev = state.premovable.events;
+  if (ev.queueSet) setTimeout(() => ev.queueSet!(state.premovable.queue.slice()), 1);
+}
+
+function emitQueueUnset(state: HeadlessState): void {
+  const ev = state.premovable.events;
+  if (ev.unset) setTimeout(() => ev.unset!(), 1);
+  if (ev.queueUnset) setTimeout(() => ev.queueUnset!(), 1);
 }
 
 // Remove the first queued premove (operate on the front of the queue).
@@ -92,12 +145,8 @@ export function cancelPremoveFront(state: HeadlessState): void {
   if (!state.premovable.queue.length) return;
   state.premovable.queue.shift();
   syncCurrentFromQueue(state);
-  if (state.premovable.queue.length)
-    callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
-  else {
-    callUserFunction(state.premovable.events.unset);
-    callUserFunction(state.premovable.events.queueUnset);
-  }
+  if (state.premovable.queue.length) emitQueueSet(state);
+  else emitQueueUnset(state);
 }
 
 // Remove the most recently queued premove.
@@ -109,12 +158,8 @@ export function popLastPremove(state: HeadlessState): void {
   if (!state.premovable.queue.length) return;
   state.premovable.queue.pop();
   syncCurrentFromQueue(state);
-  if (state.premovable.queue.length)
-    callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
-  else {
-    callUserFunction(state.premovable.events.unset);
-    callUserFunction(state.premovable.events.queueUnset);
-  }
+  if (state.premovable.queue.length) emitQueueSet(state);
+  else emitQueueUnset(state);
 }
 
 // Clear the entire premove queue (or the single current premove in single mode).
@@ -123,8 +168,7 @@ export function unsetPremoveQueue(state: HeadlessState): void {
     if (!state.premovable.queue.length && !state.premovable.current) return;
     state.premovable.queue = [];
     state.premovable.current = undefined;
-    callUserFunction(state.premovable.events.unset);
-    callUserFunction(state.premovable.events.queueUnset);
+    emitQueueUnset(state);
   } else {
     unsetPremove(state);
   }
@@ -139,7 +183,7 @@ export function unsetPremove(state: HeadlessState): void {
   }
   if (state.premovable.current) {
     state.premovable.current = undefined;
-    callUserFunction(state.premovable.events.unset);
+    if (state.premovable.events.unset) setTimeout(() => state.premovable.events.unset!(), 1);
   }
 }
 
@@ -228,7 +272,14 @@ function baseUserMove(state: HeadlessState, orig: cg.Key, dest: cg.Key): cg.Piec
   return result;
 }
 
-export function userMove(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
+export function userMove(
+  state: HeadlessState,
+  orig: cg.Key,
+  dest: cg.Key,
+  opts: { promotion?: cg.Role; reroute?: boolean } = {},
+): boolean {
+  const promotion = opts.promotion;
+  const reroute = opts.reroute === true;
   if (canMove(state, orig, dest)) {
     const result = baseUserMove(state, orig, dest);
     if (result) {
@@ -239,14 +290,14 @@ export function userMove(state: HeadlessState, orig: cg.Key, dest: cg.Key): bool
         ctrlKey: state.stats.ctrlKey,
         holdTime,
       };
+      if (promotion) metadata.promotion = promotion;
       if (result !== true) metadata.captured = result;
       callUserFunction(state.movable.events.after, orig, dest, metadata);
       return true;
     }
   } else if (canPremove(state, orig, dest)) {
-    setPremove(state, orig, dest, {
-      ctrlKey: state.stats.ctrlKey,
-    });
+    if (state.premovable.multiple && (promotion || reroute)) addToPremoveQueue(state, orig, dest, promotion, reroute);
+    else setPremove(state, orig, dest, { ctrlKey: state.stats.ctrlKey });
     unselect(state);
     return true;
   }
@@ -365,7 +416,10 @@ function canPredrop(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
 }
 
 export function isDraggable(state: HeadlessState, orig: cg.Key): boolean {
-  const piece = state.pieces.get(orig);
+  // In multiple (queue) mode a drag can also start from a virtual destination —
+  // a square that only holds a piece on the hypothetical board after the queued
+  // moves are applied. Fall back to premovePieces() so reroute drags work.
+  const piece = state.pieces.get(orig) ?? (state.premovable.multiple && premovePieces(state, orig).get(orig));
   return (
     !!piece &&
     state.draggable.enabled &&
@@ -396,12 +450,8 @@ export function playPremove(state: HeadlessState): boolean {
     if (success) {
       state.premovable.queue.shift();
       syncCurrentFromQueue(state);
-      if (state.premovable.queue.length)
-        callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
-      else {
-        callUserFunction(state.premovable.events.unset);
-        callUserFunction(state.premovable.events.queueUnset);
-      }
+      if (state.premovable.queue.length) emitQueueSet(state);
+      else emitQueueUnset(state);
     } else {
       unsetPremoveQueue(state);
     }

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,4 +1,4 @@
-import { premove } from './premove.js';
+import { premove, premovePieces } from './premove.js';
 import { type HeadlessState } from './state.js';
 import type * as cg from './types.js';
 import {
@@ -29,7 +29,7 @@ export function toggleOrientation(state: HeadlessState): void {
 export function reset(state: HeadlessState): void {
   state.lastMove = undefined;
   unselect(state);
-  unsetPremove(state);
+  unsetPremoveQueue(state);
   unsetPredrop(state);
 }
 
@@ -53,11 +53,90 @@ export function setCheck(state: HeadlessState, color: cg.Color | boolean): void 
 
 function setPremove(state: HeadlessState, orig: cg.Key, dest: cg.Key, meta: cg.SetPremoveMetadata): void {
   unsetPredrop(state);
-  state.premovable.current = [orig, dest];
+  if (state.premovable.multiple) addToPremoveQueue(state, orig, dest);
+  else {
+    state.premovable.current = [orig, dest];
+    state.premovable.queue = [];
+  }
   callUserFunction(state.premovable.events.set, orig, dest, meta);
 }
 
+function addToPremoveQueue(state: HeadlessState, orig: cg.Key, dest: cg.Key): void {
+  const queue = state.premovable.queue;
+  // Re-queueing a move that starts from an origin already used by an earlier
+  // queued item invalidates that item and everything queued after it (they were
+  // computed on a board where that piece was elsewhere), so truncate from there.
+  const idx = queue.findIndex(item => item.orig === orig);
+  if (idx !== -1) queue.length = idx;
+  // Respect the maximum queue length.
+  if (queue.length >= state.premovable.maxQueueLength) {
+    syncCurrentFromQueue(state);
+    return;
+  }
+  queue.push({ orig, dest });
+  syncCurrentFromQueue(state);
+  callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
+}
+
+function syncCurrentFromQueue(state: HeadlessState): void {
+  const front = state.premovable.queue[0];
+  state.premovable.current = front ? [front.orig, front.dest] : undefined;
+}
+
+// Remove the first queued premove (operate on the front of the queue).
+export function cancelPremoveFront(state: HeadlessState): void {
+  if (!state.premovable.multiple) {
+    unsetPremove(state);
+    return;
+  }
+  if (!state.premovable.queue.length) return;
+  state.premovable.queue.shift();
+  syncCurrentFromQueue(state);
+  if (state.premovable.queue.length)
+    callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
+  else {
+    callUserFunction(state.premovable.events.unset);
+    callUserFunction(state.premovable.events.queueUnset);
+  }
+}
+
+// Remove the most recently queued premove.
+export function popLastPremove(state: HeadlessState): void {
+  if (!state.premovable.multiple) {
+    unsetPremove(state);
+    return;
+  }
+  if (!state.premovable.queue.length) return;
+  state.premovable.queue.pop();
+  syncCurrentFromQueue(state);
+  if (state.premovable.queue.length)
+    callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
+  else {
+    callUserFunction(state.premovable.events.unset);
+    callUserFunction(state.premovable.events.queueUnset);
+  }
+}
+
+// Clear the entire premove queue (or the single current premove in single mode).
+export function unsetPremoveQueue(state: HeadlessState): void {
+  if (state.premovable.multiple) {
+    if (!state.premovable.queue.length && !state.premovable.current) return;
+    state.premovable.queue = [];
+    state.premovable.current = undefined;
+    callUserFunction(state.premovable.events.unset);
+    callUserFunction(state.premovable.events.queueUnset);
+  } else {
+    unsetPremove(state);
+  }
+}
+
 export function unsetPremove(state: HeadlessState): void {
+  // In multiple mode, interaction cleanup (e.g. ending a drag) must not wipe the
+  // whole queue — only the single-premove path clears anything here.
+  if (state.premovable.multiple) {
+    syncCurrentFromQueue(state);
+    return;
+  }
   if (state.premovable.current) {
     state.premovable.current = undefined;
     callUserFunction(state.premovable.events.unset);
@@ -65,7 +144,7 @@ export function unsetPremove(state: HeadlessState): void {
 }
 
 function setPredrop(state: HeadlessState, role: cg.Role, key: cg.Key): void {
-  unsetPremove(state);
+  unsetPremoveQueue(state);
   state.predroppable.current = { role, key };
   callUserFunction(state.predroppable.events.set, role, key);
 }
@@ -255,7 +334,10 @@ function canDrop(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
 }
 
 function isPremovable(state: HeadlessState, orig: cg.Key): boolean {
-  const piece = state.pieces.get(orig);
+  // When queuing premoves, each subsequent move "sees" the board with the
+  // earlier queued moves already applied, so selection must check the
+  // hypothetical piece board too.
+  const piece = premovePieces(state, orig).get(orig);
   return (
     !!piece &&
     state.premovable.enabled &&
@@ -293,6 +375,40 @@ export function isDraggable(state: HeadlessState, orig: cg.Key): boolean {
 }
 
 export function playPremove(state: HeadlessState): boolean {
+  // Multiple (queue) mode: attempt to play the front premove for real. If it is
+  // legal, pop it off the front and keep the rest of the chain queued for the
+  // next turn. If it has been invalidated by the opponent's move, clear the
+  // entire queue (a broken chain cannot skip ahead to item #2).
+  if (state.premovable.multiple) {
+    const front = state.premovable.queue[0];
+    if (!front) return false;
+    const { orig, dest } = front;
+    let success = false;
+    if (canMove(state, orig, dest)) {
+      const result = baseUserMove(state, orig, dest);
+      if (result) {
+        const metadata: cg.MoveMetadata = { premove: true };
+        if (result !== true) metadata.captured = result;
+        callUserFunction(state.movable.events.after, orig, dest, metadata);
+        success = true;
+      }
+    }
+    if (success) {
+      state.premovable.queue.shift();
+      syncCurrentFromQueue(state);
+      if (state.premovable.queue.length)
+        callUserFunction(state.premovable.events.queueSet, state.premovable.queue);
+      else {
+        callUserFunction(state.premovable.events.unset);
+        callUserFunction(state.premovable.events.queueUnset);
+      }
+    } else {
+      unsetPremoveQueue(state);
+    }
+    return success;
+  }
+
+  // Single-premove mode (existing behavior).
   const move = state.premovable.current;
   if (!move) return false;
   const orig = move[0],
@@ -333,7 +449,7 @@ export function playPredrop(state: HeadlessState, validate: (drop: cg.Drop) => b
 }
 
 export function cancelMove(state: HeadlessState): void {
-  unsetPremove(state);
+  unsetPremoveQueue(state);
   unsetPredrop(state);
   unselect(state);
 }

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,4 +1,4 @@
-import { applyMoveToPieces, premove, premovePieces } from './premove.js';
+import { premove, premovePieces } from './premove.js';
 import { type HeadlessState } from './state.js';
 import type * as cg from './types.js';
 import {
@@ -61,50 +61,30 @@ function setPremove(state: HeadlessState, orig: cg.Key, dest: cg.Key, meta: cg.S
   callUserFunction(state.premovable.events.set, orig, dest, meta);
 }
 
-function addToPremoveQueue(
-  state: HeadlessState,
-  orig: cg.Key,
-  dest: cg.Key,
-  promotion?: cg.Role,
-  reroute?: boolean,
-): void {
+function addToPremoveQueue(state: HeadlessState, orig: cg.Key, dest: cg.Key, promotion?: cg.Role): void {
   const queue = state.premovable.queue;
-  // Re-queueing a move that starts from an origin already used by an earlier
-  // queued item invalidates that item and everything queued after it (they were
-  // computed on a board where that piece was elsewhere), so truncate from there.
-  // Drag from a virtual destination (reroute=true) additionally lets the
-  // caller re-route by clicking a square the queue has previously placed a
-  // piece on.
-  let idx = queue.findIndex(item => item.orig === orig);
-  if (idx === -1 && reroute && !state.pieces.has(orig)) {
-    let live: cg.Pieces = state.pieces;
-    for (let i = 0; i < queue.length; i++) {
-      const item = queue[i];
-      if (!live.has(item.orig)) break;
-      const before = live;
-      live = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
-      if (live.has(orig) && before !== live) {
-        idx = i;
-        break;
-      }
-    }
-  }
+  // Re-queueing a move whose origin is already used by an earlier queued
+  // item invalidates that item and everything queued after it (they were
+  // computed on a board where that piece was elsewhere), so truncate from
+  // there and start again.
+  //
+  // This single rule is also what makes chain-building behave identically
+  // whether the piece is continued by click or by drag: continuing a piece
+  // from its *current* virtual position always targets a square that has
+  // never itself been used as a queued origin yet, so `idx` below is -1 and
+  // the move is simply appended — extending the chain by one more hop,
+  // exactly like re-selecting the piece and clicking a new square does.
+  // (An earlier version special-cased drags from a virtual square by
+  // resolving back to that hop's "true" origin and *replacing* it instead
+  // of appending — which silently collapsed a 3-square chain into a single
+  // direct hop the moment a drag was used to extend it. Re-queueing from an
+  // origin that's already in the queue — including the piece's real,
+  // never-yet-moved square — still correctly truncates and replaces from
+  // there, via the branch below; that part needs no special-casing at all.)
+  const idx = queue.findIndex(item => item.orig === orig);
   if (idx !== -1) {
-    if (reroute && queue[idx].orig !== orig) {
-      // The drag started on a square that only holds a piece on the virtual
-      // board — the destination of an earlier queued item. Keep that item's
-      // true origin and retarget its destination instead of orphaning the
-      // piece (nothing would ever move it onto `orig`). Items queued after it
-      // were computed against the old destination and are dropped.
-      const replacement = { orig: queue[idx].orig, dest, ...(promotion ? { promotion } : {}) };
-      queue.length = idx;
-      queue.push(replacement);
-    } else {
-      // Re-queueing from an origin already used by an earlier item replaces
-      // that item and everything queued after it.
-      queue.length = idx;
-      queue.push(promotion ? { orig, dest, promotion } : { orig, dest });
-    }
+    queue.length = idx;
+    queue.push(promotion ? { orig, dest, promotion } : { orig, dest });
   } else {
     // Respect the maximum queue length (normalised to at least 1).
     const cap = Math.max(1, state.premovable.maxQueueLength | 0);
@@ -276,10 +256,9 @@ export function userMove(
   state: HeadlessState,
   orig: cg.Key,
   dest: cg.Key,
-  opts: { promotion?: cg.Role; reroute?: boolean } = {},
+  opts: { promotion?: cg.Role } = {},
 ): boolean {
   const promotion = opts.promotion;
-  const reroute = opts.reroute === true;
   if (canMove(state, orig, dest)) {
     const result = baseUserMove(state, orig, dest);
     if (result) {
@@ -296,7 +275,7 @@ export function userMove(
       return true;
     }
   } else if (canPremove(state, orig, dest)) {
-    if (state.premovable.multiple && (promotion || reroute)) addToPremoveQueue(state, orig, dest, promotion, reroute);
+    if (state.premovable.multiple) addToPremoveQueue(state, orig, dest, promotion);
     else setPremove(state, orig, dest, { ctrlKey: state.stats.ctrlKey });
     unselect(state);
     return true;
@@ -416,10 +395,19 @@ function canPredrop(state: HeadlessState, orig: cg.Key, dest: cg.Key): boolean {
 }
 
 export function isDraggable(state: HeadlessState, orig: cg.Key): boolean {
-  // In multiple (queue) mode a drag can also start from a virtual destination —
-  // a square that only holds a piece on the hypothetical board after the queued
-  // moves are applied. Fall back to premovePieces() so reroute drags work.
-  const piece = state.pieces.get(orig) ?? (state.premovable.multiple && premovePieces(state, orig).get(orig));
+  // In multiple (queue) mode, prefer the hypothetical (queue-applied) board
+  // over the real one: if `orig` is currently the destination of a queued
+  // premove, the queued piece is what's actually shown there and what a
+  // drag should pick up — even when a real piece also still occupies that
+  // square. That includes a capture, and specifically a "defensive" premove
+  // onto one of the player's own pieces in anticipation of the opponent
+  // taking it first, where the real board keeps the friendly piece in place
+  // right up until the premove actually executes. Checking the real board
+  // first (as this used to) would grab that stale friendly piece instead of
+  // the queued attacker, making the attacker impossible to premove further.
+  const piece = state.premovable.multiple
+    ? (premovePieces(state, orig).get(orig) ?? state.pieces.get(orig))
+    : state.pieces.get(orig);
   return (
     !!piece &&
     state.draggable.enabled &&

--- a/src/chessground.ts
+++ b/src/chessground.ts
@@ -2,6 +2,7 @@ import { type Api, start } from './api.js';
 import * as autoPieces from './autoPieces.js';
 import { type Config, configure } from './config.js';
 import * as events from './events.js';
+import * as premovePiecesLayer from './premovePieces.js';
 import { render, renderResized, updateBounds } from './render.js';
 import { defaults, type HeadlessState, type State } from './state.js';
 import * as svg from './svg.js';
@@ -25,12 +26,14 @@ export function Chessground(element: HTMLElement, config?: Config): Api {
       bounds = util.memo(() => elements.board.getBoundingClientRect()),
       redrawNow = (skipSvg?: boolean): void => {
         render(state);
+        if (elements.premovePieces) premovePiecesLayer.render(state, elements.premovePieces);
         if (elements.autoPieces) autoPieces.render(state, elements.autoPieces);
         if (!skipSvg && elements.shapes) svg.renderSvg(state, elements);
       },
       onResize = (): void => {
         updateBounds(state);
         renderResized(state);
+        if (elements.premovePieces) premovePiecesLayer.renderResized(state);
         if (elements.autoPieces) autoPieces.renderResized(state);
       };
     const state = maybeState as State;

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,13 +114,46 @@ export function configure(state: HeadlessState, config: Config): void {
   if (config.movable?.dests) state.movable.dests = undefined;
   if (config.drawable?.autoShapes) state.drawable.autoShapes = [];
 
+  // remember premovable mode before merge so we can detect a switch and a new
+  // maxQueueLength: a host switching from single→queue (or vice versa), or
+  // shrinking the cap below the current queue length, must invalidate stale
+  // queue entries so callers don't act on impossible chains.
+  const prevMultiple = state.premovable.multiple;
+  const prevMax = state.premovable.maxQueueLength;
+
   deepMerge(state, config);
 
-  // if a fen was provided, replace the pieces
+  // Normalize maxQueueLength: non-positive values are treated as 1.
+  if (!Number.isFinite(state.premovable.maxQueueLength) || state.premovable.maxQueueLength < 1) {
+    state.premovable.maxQueueLength = 1;
+  }
+
+  // If a fen was provided, replace the pieces. The queued premoves are *not*
+  // cleared here: like the classic single premove, a chain is speculative by
+  // nature and the host re-validates it against `movable.dests` when it calls
+  // playPremove() after the board changes. Clearing on every FEN update would
+  // make multi-premove chains impossible in real online play, where the
+  // opponent's move arrives as a fresh FEN just before the user's turn. Hosts
+  // that replace the whole board (new game, analysis navigation, etc.) should
+  // cancel the queue explicitly via api.cancelPremoveQueue().
   if (config.fen) {
     state.pieces = fenRead(config.fen);
     state.drawable.shapes = config.drawable?.shapes || [];
   }
+
+  // Switching between single and queue mode also invalidates any saved premove.
+  if (config.premovable && config.premovable.multiple !== undefined && config.premovable.multiple !== prevMultiple) {
+    state.premovable.queue = [];
+    state.premovable.current = undefined;
+  }
+
+  // If the cap was lowered below the current queue length, truncate.
+  if (state.premovable.queue.length > state.premovable.maxQueueLength) {
+    state.premovable.queue.length = state.premovable.maxQueueLength;
+    const front = state.premovable.queue[0];
+    state.premovable.current = front ? [front.orig, front.dest] : undefined;
+  }
+  void prevMax;
 
   // apply config values that could be undefined yet meaningful
   if ('check' in config) setCheck(state, config.check || false);

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,10 +49,14 @@ export interface Config {
     castle?: boolean; // whether to allow king castle premoves
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
+    multiple?: boolean; // allow a queue of several premoves (chess.com-style chain)
+    maxQueueLength?: number; // maximum number of premoves that can be queued
     additionalPremoveRequirements?: cg.Mobility;
     events?: {
       set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
       unset?: () => void; // called after the premove has been unset
+      queueSet?: (queue: cg.Premove[]) => void; // called after the queue changes
+      queueUnset?: () => void; // called after the queue is emptied
     };
   };
   predroppable?: {
@@ -89,6 +93,7 @@ export interface Config {
     // Clicking an empty square or immovable piece will clear the drawing regardless, but when this property is true,
     // clicking on a (currently unselected) movable piece will also clear the drawing.
     eraseOnMovablePieceClick?: boolean;
+    knightMoveBend?: boolean; // draw knight-move arrows as a right-angle "L" instead of a straight line
     shapes?: DrawShape[];
     autoShapes?: DrawShape[];
     brushes?: DrawBrushes;

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -30,18 +30,18 @@ export function start(s: State, e: cg.MouchEvent): void {
     position = util.eventPosition(e)!,
     orig = board.getKeyAtDomPos(position, board.whitePov(s), bounds);
   if (!orig) return;
-  // Look up the piece on the virtual (queued) board first so dragging from a
-  // chess.com-style virtual destination drags the right piece. Fall back to
-  // the authoritative board when there is no virtual piece there.
-  const virtual = fullPremovePieces(s);
-  let piece: cg.Piece | undefined;
-  let premoveStage: number | undefined;
-  if (virtual.has(orig) && !s.pieces.has(orig)) {
-    piece = virtual.get(orig);
-    premoveStage = stageAt(s, orig);
-  } else {
-    piece = s.pieces.get(orig);
-  }
+  // Prioritise the virtual (queued) board whenever `orig` is currently the
+  // destination of some queued premove, even when a real piece also still
+  // sits there — a capture, including a "defensive" premove onto one of the
+  // player's own pieces in anticipation of the opponent taking it first (the
+  // real board keeps that friendly piece in place until the premove actually
+  // executes). stageAt() is the source of truth for "is a queued piece
+  // actually shown here right now" — it returns undefined once the chain has
+  // moved further and superseded this square, so falling back to the
+  // authoritative board in that case is correct too (there's nothing virtual
+  // left to grab there).
+  const premoveStage = stageAt(s, orig);
+  const piece = premoveStage !== undefined ? fullPremovePieces(s).get(orig) : s.pieces.get(orig);
   const previouslySelected = s.selected;
   if (
     !previouslySelected &&
@@ -234,10 +234,11 @@ export function end(s: State, e: cg.MouchEvent): void {
     if (cur.newPiece) board.dropNewPiece(s, cur.orig, dest, cur.force);
     else {
       s.stats.ctrlKey = e.ctrlKey;
-      // Drags from a virtual piece layer entry are reroutes: the queue stage
-      // whose virtual dest was the drag origin should be replaced.
-      if (board.userMove(s, cur.orig, dest, { reroute: cur.premoveStage !== undefined }))
-        s.stats.dragged = true;
+      // A drag from a virtual (queued) piece layer entry lands here with
+      // cur.orig equal to that piece's current virtual square; userMove()
+      // treats that exactly like clicking the piece and clicking dest — it
+      // extends the chain by one more hop from wherever it's called with.
+      if (board.userMove(s, cur.orig, dest)) s.stats.dragged = true;
     }
   } else if (cur.newPiece) {
     s.pieces.delete(cur.orig);

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -1,6 +1,8 @@
 import { anim } from './anim.js';
 import * as board from './board.js';
 import { clear as drawClear } from './draw.js';
+import { fullPremovePieces } from './premove.js';
+import { stageAt } from './premovePieces.js';
 import { type State } from './state.js';
 import type * as cg from './types.js';
 import * as util from './util.js';
@@ -17,6 +19,7 @@ export interface DragCurrent {
   previouslySelected?: cg.Key;
   originTarget: EventTarget | null;
   keyHasChanged: boolean; // whether the drag has left the orig key
+  premoveStage?: number; // queue stage this drag originates from (virtual piece)
 }
 
 export function start(s: State, e: cg.MouchEvent): void {
@@ -27,7 +30,18 @@ export function start(s: State, e: cg.MouchEvent): void {
     position = util.eventPosition(e)!,
     orig = board.getKeyAtDomPos(position, board.whitePov(s), bounds);
   if (!orig) return;
-  const piece = s.pieces.get(orig);
+  // Look up the piece on the virtual (queued) board first so dragging from a
+  // chess.com-style virtual destination drags the right piece. Fall back to
+  // the authoritative board when there is no virtual piece there.
+  const virtual = fullPremovePieces(s);
+  let piece: cg.Piece | undefined;
+  let premoveStage: number | undefined;
+  if (virtual.has(orig) && !s.pieces.has(orig)) {
+    piece = virtual.get(orig);
+    premoveStage = stageAt(s, orig);
+  } else {
+    piece = s.pieces.get(orig);
+  }
   const previouslySelected = s.selected;
   if (
     !previouslySelected &&
@@ -53,7 +67,12 @@ export function start(s: State, e: cg.MouchEvent): void {
     board.selectSquare(s, orig);
   }
   const stillSelected = s.selected === orig;
-  const element = pieceElementByKey(s, orig);
+  // Prefer a virtual piece element when dragging from a virtual stage so the
+  // user sees the moved piece under their finger. Falling back to the
+  // authoritative element keeps non-queued drags working.
+  const element = premoveStage !== undefined
+    ? virtualPieceElementByKey(s, orig) ?? pieceElementByKey(s, orig)
+    : pieceElementByKey(s, orig);
   if (piece && element && stillSelected && board.isDraggable(s, orig)) {
     s.draggable.current = {
       orig,
@@ -65,6 +84,7 @@ export function start(s: State, e: cg.MouchEvent): void {
       previouslySelected,
       originTarget: e.target,
       keyHasChanged: false,
+      premoveStage,
     };
     element.cgDragging = true;
     element.classList.add('dragging');
@@ -122,8 +142,11 @@ function processDrag(s: State): void {
     if (!cur) return;
     // cancel animations while dragging
     if (s.animation.current?.plan.anims.has(cur.orig)) s.animation.current = undefined;
-    // if moving piece is gone, cancel
-    const origPiece = s.pieces.get(cur.orig);
+    // if moving piece is gone, cancel. The originating piece may live on the
+    // virtual (queued) board for staged premoves; consult the virtual map
+    // before falling back to the authoritative board.
+    const virtual = fullPremovePieces(s);
+    const origPiece = virtual.get(cur.orig) ?? s.pieces.get(cur.orig);
     if (!origPiece || !util.samePiece(origPiece, cur.piece)) cancel(s);
     else {
       if (!cur.started && util.distanceSq(cur.pos, cur.origPos) >= Math.pow(s.draggable.distance, 2))
@@ -211,7 +234,10 @@ export function end(s: State, e: cg.MouchEvent): void {
     if (cur.newPiece) board.dropNewPiece(s, cur.orig, dest, cur.force);
     else {
       s.stats.ctrlKey = e.ctrlKey;
-      if (board.userMove(s, cur.orig, dest)) s.stats.dragged = true;
+      // Drags from a virtual piece layer entry are reroutes: the queue stage
+      // whose virtual dest was the drag origin should be replaced.
+      if (board.userMove(s, cur.orig, dest, { reroute: cur.premoveStage !== undefined }))
+        s.stats.dragged = true;
     }
   } else if (cur.newPiece) {
     s.pieces.delete(cur.orig);
@@ -251,6 +277,17 @@ function pieceElementByKey(s: State, key: cg.Key): cg.PieceNode | undefined {
     if ((el as cg.KeyedNode).cgKey === key && (el as cg.KeyedNode).tagName === 'PIECE')
       return el as cg.PieceNode;
     el = el.nextSibling;
+  }
+  return undefined;
+}
+
+function virtualPieceElementByKey(s: State, key: cg.Key): cg.PieceNode | undefined {
+  const layer = s.dom.elements.premovePieces;
+  if (!layer) return undefined;
+  let el = layer.firstChild as cg.PieceNode | null;
+  while (el) {
+    if ((el as cg.KeyedNode).cgKey === key) return el;
+    el = el.nextSibling as cg.PieceNode | null;
   }
   return undefined;
 }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -45,6 +45,7 @@ export interface Drawable {
   visible: boolean; // can view
   defaultSnapToValidMove: boolean;
   eraseOnMovablePieceClick: boolean;
+  knightMoveBend: boolean; // draw knight-move arrows as a right-angle "L" instead of a straight line
   onChange?: (shapes: DrawShape[]) => void;
   shapes: DrawShape[]; // user shapes
   autoShapes: DrawShape[]; // computer shapes

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -28,8 +28,44 @@ const king: Mobility = (ctx: MobilityContext) =>
 
 const mobilityByRole = { pawn, knight, bishop, rook, queen, king };
 
-export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
-  const pieces = state.pieces;
+/**
+ * Virtually applies a single move to a pieces map and returns a new map.
+ * The moved piece is relocated and any piece on the destination square is
+ * captured (overwritten). Like the rest of premove logic, this intentionally
+ * ignores promotion, en-passant and castling-rights details — it only needs to
+ * be good enough to compute legal destination squares for the next queued
+ * premove on a hypothetical board.
+ */
+export function applyMoveToPieces(pieces: cg.Pieces, orig: cg.Key, dest: cg.Key): cg.Pieces {
+  const piece = pieces.get(orig);
+  if (!piece) return pieces;
+  const entries: [cg.Key, cg.Piece][] = [];
+  for (const [key, p] of pieces) if (key !== orig) entries.push([key, p]);
+  entries.push([dest, piece]);
+  return new Map(entries);
+}
+
+/**
+ * The pieces map that should be used to compute premove destinations for `orig`:
+ * the real board with the queued premoves already applied on top. When premoving
+ * is not in "multiple" (queue) mode, or the queue is empty, this is simply the
+ * current board.
+ *
+ * When `orig` is an origin already used by an earlier queued item, re-queueing
+ * from it replaces that item and everything queued after it, so the hypothetical
+ * board only applies the items before that one.
+ */
+export function premovePieces(state: HeadlessState, orig?: cg.Key): cg.Pieces {
+  if (!state.premovable.multiple) return state.pieces;
+  const queue = state.premovable.queue;
+  const idx = orig === undefined ? -1 : queue.findIndex(item => item.orig === orig);
+  const effective = idx === -1 ? queue : queue.slice(0, idx);
+  let pieces = state.pieces;
+  for (const item of effective) pieces = applyMoveToPieces(pieces, item.orig, item.dest);
+  return pieces;
+}
+
+function premoveFromState(state: HeadlessState, pieces: cg.Pieces, key: cg.Key): cg.Key[] {
   const piece = pieces.get(key);
   if (!piece || piece.color === state.turnColor) return [];
   const color = piece.color,
@@ -54,4 +90,8 @@ export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
     };
   // todo - remove more properties from MobilityContext that aren't used in this file, and adjust as needed in lila.
   return util.allPosAndKey.filter(dest => mobility({ ...partialCtx, dest })).map(pk => pk.key);
+}
+
+export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
+  return premoveFromState(state, premovePieces(state, key), key);
 }

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -117,18 +117,12 @@ export function applyMoveToPieces(
  */
 export function premovePieces(state: HeadlessState, orig?: cg.Key): cg.Pieces {
   if (!state.premovable.multiple) return state.pieces;
-  const queue = state.premovable.queue;
-  const idx = orig === undefined ? -1 : queue.findIndex(item => item.orig === orig);
-  const effective = idx === -1 ? queue : queue.slice(0, idx);
-  let pieces: cg.Pieces = state.pieces;
-  for (const item of effective) {
-    const before = pieces;
-    pieces = applyMoveToPieces(pieces, item.orig, item.dest, { promotion: item.promotion });
-    // If the origin disappeared (capture, en-passant, castling relocation
-    // removing a piece from orig) then the chain is broken from this point on.
-    if (pieces === before && !before.has(item.orig)) break;
-  }
-  return pieces;
+  const cut = orig === undefined ? state.premovable.queue.length : premoveCutIndex(state, orig);
+  const truncated: HeadlessState = {
+    ...state,
+    premovable: { ...state.premovable, queue: state.premovable.queue.slice(0, cut) },
+  };
+  return computeVirtualBoard(truncated).pieces;
 }
 
 /**
@@ -137,13 +131,7 @@ export function premovePieces(state: HeadlessState, orig?: cg.Key): cg.Pieces {
  * `state.pieces`. Stops at the first broken item.
  */
 export function fullPremovePieces(state: HeadlessState): cg.Pieces {
-  let pieces: cg.Pieces = state.pieces;
-  for (const item of state.premovable.queue) {
-    const before = pieces;
-    pieces = applyMoveToPieces(pieces, item.orig, item.dest, { promotion: item.promotion });
-    if (pieces === before && !before.has(item.orig)) break;
-  }
-  return pieces;
+  return computeVirtualBoard(state).pieces;
 }
 
 function premoveFromState(state: HeadlessState, pieces: cg.Pieces, key: cg.Key): cg.Key[] {
@@ -175,4 +163,78 @@ function premoveFromState(state: HeadlessState, pieces: cg.Pieces, key: cg.Key):
 
 export function premove(state: HeadlessState, key: cg.Key): cg.Key[] {
   return premoveFromState(state, premovePieces(state, key), key);
+}
+
+export interface VirtualBoard {
+  /** تخته‌ی فرضی بعد از اعمال بخش معتبر صف */
+  pieces: cg.Pieces;
+  /** key → آخرین stage ای که مهره‌ای روی این خونه گذاشته */
+  placedBy: Map<cg.Key, number>;
+  /** خونه‌هایی که رخِ قلعه در آن‌ها نشسته (نه dest خود آیتم) */
+  castlingRooks: Set<cg.Key>;
+  /** تعداد آیتم‌هایی که با موفقیت اعمال شدند (زنجیره از این‌جا به بعد شکسته) */
+  validStages: number;
+}
+
+/**
+ * صف را stage به stage اعمال می‌کند و علاوه بر تخته‌ی نهایی، برای هر خونه
+ * ثبت می‌کند چه stage ای آن را پر کرده. تشخیص تغییر با identity مهره است،
+ * چون applyMoveToPieces آبجکت‌های دست‌نخورده را همان‌طور کپی می‌کند.
+ */
+export function computeVirtualBoard(state: HeadlessState): VirtualBoard {
+  const placedBy = new Map<cg.Key, number>();
+  const castlingRooks = new Set<cg.Key>();
+  let pieces: cg.Pieces = state.pieces;
+  let validStages = 0;
+  if (!state.premovable.multiple) return { pieces, placedBy, castlingRooks, validStages };
+
+  const queue = state.premovable.queue;
+  for (let i = 0; i < queue.length; i++) {
+    const item = queue[i];
+    const before = pieces;
+    if (!before.has(item.orig)) break; // زنجیره شکسته
+    pieces = applyMoveToPieces(before, item.orig, item.dest, { promotion: item.promotion });
+    validStages = i + 1;
+
+    // خونه‌هایی که خالی شدند (مبدأ، رخ قلعه از h1/a1، پیاده‌ی آن‌پاسان)
+    for (const [k] of before) {
+      if (!pieces.has(k)) {
+        placedBy.delete(k);
+        castlingRooks.delete(k);
+      }
+    }
+    // خونه‌هایی که محتوایشان عوض شد (dest، خونه‌ی جدید رخ، ارتقا)
+    for (const [k, p] of pieces) {
+      if (before.get(k) === p) continue;
+      placedBy.set(k, i);
+      if (k === item.dest) castlingRooks.delete(k);
+      else castlingRooks.add(k);
+    }
+  }
+  return { pieces, placedBy, castlingRooks, validStages };
+}
+
+/** مهره‌ای که «روی تخته‌ی فرضی» در این خونه است (منبع حقیقت برای انتخاب/درگ) */
+export function virtualPieceAt(state: HeadlessState, key: cg.Key): cg.Piece | undefined {
+  return computeVirtualBoard(state).pieces.get(key);
+}
+
+/**
+ * وقتی کاربر از `orig` پیش‌حرکت جدید می‌زند، صف باید تا کجا نگه داشته شود؟
+ * از آخر صف به عقب می‌گردیم و به اولین رخدادِ مربوط به این خونه نگاه می‌کنیم:
+ *  - آخرین رخداد «ورود» بود (dest) → مهره‌ی روی این خونه همان مهره‌ی صف است → ادامه‌ی زنجیره؛ کل صف می‌ماند
+ *  - آخرین رخداد «خروج» بود (orig) → کاربر دارد همان آیتم را از نو مسیریابی می‌کند → از همان‌جا برش
+ *  - هیچ‌کدام → کل صف می‌ماند
+ *
+ * (findIndex(item.orig === orig) قبلی اشتباه بود: اگر خونه بعداً دوباره پر شده
+ * باشد، برش از اولین خروج باعث می‌شد مهره‌ی اشتباه دیده شود و نشود ادامه داد.)
+ */
+export function premoveCutIndex(state: HeadlessState, orig: cg.Key): number {
+  const queue = state.premovable.queue;
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const item = queue[i];
+    if (item.dest === orig) return queue.length;
+    if (item.orig === orig) return i;
+  }
+  return queue.length;
 }

--- a/src/premove.ts
+++ b/src/premove.ts
@@ -28,20 +28,75 @@ const king: Mobility = (ctx: MobilityContext) =>
 
 const mobilityByRole = { pawn, knight, bishop, rook, queen, king };
 
+function isPromotingMove(_orig: cg.Key, dest: cg.Key, piece: cg.Piece): boolean {
+  if (piece.role !== 'pawn') return false;
+  const destRank = dest[1];
+  return (piece.color === 'white' && destRank === '8') || (piece.color === 'black' && destRank === '1');
+}
+
 /**
- * Virtually applies a single move to a pieces map and returns a new map.
- * The moved piece is relocated and any piece on the destination square is
- * captured (overwritten). Like the rest of premove logic, this intentionally
- * ignores promotion, en-passant and castling-rights details — it only needs to
- * be good enough to compute legal destination squares for the next queued
- * premove on a hypothetical board.
+ * Apply a single premove to a pieces map and return a new map. Captures any
+ * piece on the destination square, and additionally:
+ *
+ *  - For pawn promotion, relocates the pawn then transforms it to the requested
+ *    promotion role on the destination square. If no promotion role is supplied
+ *    for a promoting pawn, it defaults to queen (the overwhelmingly common case
+ *    and what chess.com does).
+ *  - For castling (king moves two squares on its back rank), also relocates the
+ *    corresponding rook on the same rank. This keeps the hypothetical board
+ *    consistent so subsequent queued moves on the rook or king make sense.
+ *  - For en passant (a pawn captures diagonally to an empty square), removes the
+ *    captured pawn from the file it crosses. Detection is purely geometric and
+ *    does not require en-passant rights state.
+ *
+ * If the origin square is empty in `pieces`, the move is dropped: the board is
+ * returned unchanged so callers can detect a broken chain.
  */
-export function applyMoveToPieces(pieces: cg.Pieces, orig: cg.Key, dest: cg.Key): cg.Pieces {
+export function applyMoveToPieces(
+  pieces: cg.Pieces,
+  orig: cg.Key,
+  dest: cg.Key,
+  opts?: { promotion?: cg.Role },
+): cg.Pieces {
   const piece = pieces.get(orig);
   if (!piece) return pieces;
   const entries: [cg.Key, cg.Piece][] = [];
   for (const [key, p] of pieces) if (key !== orig) entries.push([key, p]);
-  entries.push([dest, piece]);
+
+  // En passant: pawn captures diagonally to an empty square.
+  if (piece.role === 'pawn' && !pieces.has(dest) && orig[0] !== dest[0]) {
+    const capturedRank = orig[1];
+    const capturedKey = (dest[0] + capturedRank) as cg.Key;
+    const captured = pieces.get(capturedKey);
+    if (captured && captured.role === 'pawn' && captured.color !== piece.color) {
+      // Drop the captured pawn from the entries.
+      for (let i = entries.length - 1; i >= 0; i--) if (entries[i][0] === capturedKey) entries.splice(i, 1);
+    }
+  }
+
+  let movingPiece: cg.Piece = piece;
+  if (isPromotingMove(orig, dest, piece)) {
+    movingPiece = { ...piece, role: opts?.promotion ?? 'queen', promoted: true };
+  }
+
+  entries.push([dest, movingPiece]);
+
+  // Castling: king moving two squares on its back rank.
+  if (piece.role === 'king' && orig[1] === dest[1] && Math.abs(orig.charCodeAt(0) - dest.charCodeAt(0)) === 2) {
+    const rank = orig[1];
+    const kingDestFile = dest[0];
+    const rookFromFile = kingDestFile === 'g' ? 'h' : kingDestFile === 'c' ? 'a' : null;
+    const rookToFile = kingDestFile === 'g' ? 'f' : kingDestFile === 'c' ? 'd' : null;
+    if (rookFromFile && rookToFile) {
+      const rookKey = (rookFromFile + rank) as cg.Key;
+      const rook = pieces.get(rookKey);
+      if (rook && rook.role === 'rook' && rook.color === piece.color) {
+        for (let i = entries.length - 1; i >= 0; i--) if (entries[i][0] === rookKey) entries.splice(i, 1);
+        entries.push([(rookToFile + rank) as cg.Key, rook]);
+      }
+    }
+  }
+
   return new Map(entries);
 }
 
@@ -54,14 +109,40 @@ export function applyMoveToPieces(pieces: cg.Pieces, orig: cg.Key, dest: cg.Key)
  * When `orig` is an origin already used by an earlier queued item, re-queueing
  * from it replaces that item and everything queued after it, so the hypothetical
  * board only applies the items before that one.
+ *
+ * If any queued item's origin is missing on the resulting hypothetical board
+ * (because a prior step's capture or castling relocation invalidated it), that
+ * item is silently skipped — the chain breaks rather than misapplying later
+ * moves to the wrong board.
  */
 export function premovePieces(state: HeadlessState, orig?: cg.Key): cg.Pieces {
   if (!state.premovable.multiple) return state.pieces;
   const queue = state.premovable.queue;
   const idx = orig === undefined ? -1 : queue.findIndex(item => item.orig === orig);
   const effective = idx === -1 ? queue : queue.slice(0, idx);
-  let pieces = state.pieces;
-  for (const item of effective) pieces = applyMoveToPieces(pieces, item.orig, item.dest);
+  let pieces: cg.Pieces = state.pieces;
+  for (const item of effective) {
+    const before = pieces;
+    pieces = applyMoveToPieces(pieces, item.orig, item.dest, { promotion: item.promotion });
+    // If the origin disappeared (capture, en-passant, castling relocation
+    // removing a piece from orig) then the chain is broken from this point on.
+    if (pieces === before && !before.has(item.orig)) break;
+  }
+  return pieces;
+}
+
+/**
+ * Returns the full virtual pieces map with the entire premove queue applied in
+ * order. Used by the renderer for the virtual pieces layer; never mutates
+ * `state.pieces`. Stops at the first broken item.
+ */
+export function fullPremovePieces(state: HeadlessState): cg.Pieces {
+  let pieces: cg.Pieces = state.pieces;
+  for (const item of state.premovable.queue) {
+    const before = pieces;
+    pieces = applyMoveToPieces(pieces, item.orig, item.dest, { promotion: item.promotion });
+    if (pieces === before && !before.has(item.orig)) break;
+  }
   return pieces;
 }
 

--- a/src/premovePieces.ts
+++ b/src/premovePieces.ts
@@ -4,76 +4,111 @@ import { type State } from './state.js';
 import type * as cg from './types.js';
 import { createEl, key2pos, posToTranslate as posToTranslateFromBounds, translate } from './util.js';
 
+type Placement = { key: cg.Key; piece: cg.Piece };
+
 type VirtualStage = {
   stage: number;
   orig: cg.Key;
+  // The queue item's own destination — the "primary" square of this stage.
+  // For a normal move this is the only placement; for castling it's the
+  // king's landing square specifically (the rook's is a second, secondary
+  // placement). This is also the square stageAt()/drag.ts look for when
+  // deciding what a drag starting here should grab and reroute.
   dest: cg.Key;
-  piece: cg.Piece;
-  capturedAtDest: cg.Piece | undefined;
-  // True when a *later, successfully-computed* stage continues the move from
-  // this stage's `dest` — i.e. the same piece keeps advancing further down
-  // the chain. Such a stage is a transient waypoint on the hypothetical
-  // board, not a resting square, and must never get its own piece node: only
-  // the final square of a same-piece chain should ever show a piece. Without
-  // this, a piece re-premoved two or three times in a row (e.g. a bishop
-  // queued d2-c3, then c3-b4) renders once per hop instead of once at its
-  // actual final square.
-  superseded: boolean;
+  // Every square that gets a virtual piece drawn for this stage, already
+  // filtered down to the ones still current (see below).
+  placements: Placement[];
+  // Every square whose authoritative (real) piece must stay hidden because
+  // this stage's hypothetical board no longer has that piece there: the
+  // mover's own origin, a captured piece sitting on the destination
+  // (including one of the player's own pieces, in a "defend the square"
+  // premove that expects the opponent to capture it first so this piece can
+  // recapture), a castling rook's origin, or an en-passant-captured pawn.
+  hidden: cg.Key[];
 };
 
-// Diff between authoritative `state.pieces` and the virtual map. The virtual
-// layer draws the moved piece at its destination, hides the source piece, and
-// shows the captured piece (if any) fading on the destination — same visual
-// contract as a real move. We compute one stage per queued item so the renderer
-// can tag each with a stage class (for stage-aware re-queueing on drag).
+// Diffs the pieces map before/after one queued move is hypothetically
+// applied. This is what lets a single queue item translate into more than
+// one visual change: a castling move relocates the rook as well as the
+// king, and a capture — including a capture of the player's own piece —
+// must hide whatever was really sitting on the destination, not just draw
+// the mover on top of it.
+function diffPieces(before: cg.Pieces, after: cg.Pieces): { placements: Placement[]; hidden: cg.Key[] } {
+  const placements: Placement[] = [];
+  const hidden: cg.Key[] = [];
+  const keys = new Set<cg.Key>([...before.keys(), ...after.keys()]);
+  for (const key of keys) {
+    const b = before.get(key);
+    const a = after.get(key);
+    const same = !!a && !!b && a.color === b.color && a.role === b.role && a.promoted === b.promoted;
+    if (same) continue;
+    if (b) hidden.push(key);
+    if (a) placements.push({ key, piece: a });
+  }
+  return { placements, hidden };
+}
+
+// Diff between authoritative `state.pieces` and the virtual map, one stage
+// per queued item. `applyMoveToPieces` already understands castling,
+// en passant and promotion; diffPieces() turns whatever it changed into the
+// squares a stage needs to draw or hide, so all three fall out for free
+// instead of needing separate special-casing here.
 function computeStages(state: State): VirtualStage[] {
   if (!state.premovable.multiple || !state.premovable.queue.length) return [];
   const queue = state.premovable.queue;
-  const raw: Omit<VirtualStage, 'superseded'>[] = [];
+  const raw: VirtualStage[] = [];
   let live: cg.Pieces = state.pieces;
   for (let i = 0; i < queue.length; i++) {
     const item = queue[i];
-    const piece = live.get(item.orig);
-    if (!piece) break;
-    const destPiece = live.get(item.dest);
-    const captured = destPiece && destPiece.color !== piece.color ? destPiece : undefined;
-    raw.push({ stage: i, orig: item.orig, dest: item.dest, piece, capturedAtDest: captured });
-    live = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
+    if (!live.has(item.orig)) break;
+    const next = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
+    const { placements, hidden } = diffPieces(live, next);
+    raw.push({ stage: i, orig: item.orig, dest: item.dest, placements, hidden });
+    live = next;
   }
-  // Superseded-ness is resolved against `raw` (the stages we actually
-  // validated above), never against the untouched tail of `queue`: an item
-  // sitting after a broken link in the chain was never reached by the loop
-  // above, so it must not be allowed to suppress an earlier, real resting
-  // square just because its `orig` happens to match that square's `dest`.
+  // A placement is superseded — and must not be drawn — when a later,
+  // successfully-computed stage continues the move from that exact square
+  // (the same piece keeps advancing further down the chain). This is
+  // resolved per *placement*, not per stage, and only against `raw` (the
+  // stages actually validated above, never the untouched tail of `queue`):
+  // a castling move's rook placement and its king placement can have
+  // different fates if only the king gets re-premoved further afterwards,
+  // and an item sitting after a broken link in the chain was never reached
+  // by the loop above, so it must not suppress a real resting square just
+  // because its `orig` happens to match that square's key.
   return raw.map((stage, i) => ({
     ...stage,
-    superseded: raw.slice(i + 1).some(later => later.orig === stage.dest),
+    placements: stage.placements.filter(p => !raw.slice(i + 1).some(later => later.orig === p.key)),
   }));
 }
 
 /**
  * Render the virtual premove pieces layer. Walks the queue stage-by-stage and
- * adds piece nodes for the moved piece at its current destination. Sets a
- * `.premove-piece` class plus a stage-ordinal class for each node. The CSS
- * hides the corresponding authoritative source node visually.
+ * adds piece nodes for every square each stage places a piece on — normally
+ * just the mover's destination, but two for a castling move (king + rook).
+ * Sets a `.premove-piece` class plus a stage-ordinal class for each node.
+ * The CSS hides the corresponding authoritative source node visually.
  *
- * Two things this reconciles carefully, rather than doing a naive "wipe and
- * rebuild" every call:
+ * Three things this reconciles carefully, rather than doing a naive "wipe
+ * and rebuild" every call:
  *
  *  - A chain that re-premoves the *same* piece several times (e.g. a bishop
- *    queued d2-c3, then c3-b4) produces one stage per hop, but only the last
- *    hop is a real resting square — see `superseded` above. Waypoint stages
- *    are skipped entirely so the piece is drawn exactly once, at its actual
- *    final square.
+ *    queued d2-c3, then c3-b4) produces one stage per hop, but only the
+ *    last hop is a real resting square — see the `placements` filtering in
+ *    computeStages(). Superseded placements are skipped entirely so a piece
+ *    is drawn exactly once, at its actual current square.
+ *  - A capture — including a "defensive" premove onto one of the player's
+ *    own pieces — must hide whatever piece is really still sitting on the
+ *    destination (the real capture hasn't happened yet), or the mover and
+ *    the piece it's about to take appear stacked on the same square.
  *  - If the piece currently being dragged *is* one of these virtual nodes
  *    (the user grabbed the piece from its premove destination to re-target
- *    or extend the chain), that DOM node must not be destroyed and recreated
- *    here. processDrag() (in drag.ts) holds a direct reference to it and
- *    keeps translating it every animation frame; replacing it with a fresh
- *    element would silently detach the one actually being dragged, so the
- *    piece would stop following the cursor even though the drag is still
- *    "live" underneath — which is why, before this fix, drag only ever
- *    visibly worked for the very first premove.
+ *    or extend the chain), that DOM node must not be destroyed and
+ *    recreated here. processDrag() (in drag.ts) holds a direct reference to
+ *    it and keeps translating it every animation frame; replacing it with a
+ *    fresh element would silently detach the one actually being dragged, so
+ *    the piece would stop following the cursor even though the drag is
+ *    still "live" underneath.
  *
  * This renderer never mutates state.pieces. It also never reads back the FEN —
  * callers (e.g. drag handler) can keep using `state.pieces` / `getFen()` as the
@@ -85,68 +120,66 @@ export function render(state: State, el: HTMLElement): void {
   const stages = computeStages(state);
   const dragStage = state.draggable.current?.premoveStage;
 
-  // Index existing virtual nodes by the stage they represent, so unaffected
-  // ones — in particular the one currently being dragged — can be left
-  // alone instead of being wiped and recreated.
-  const existingByStage = new Map<number, cg.PieceNode>();
+  // Index existing virtual nodes by a stable per-placement id (`stage:key`),
+  // since a single stage can now place more than one piece (castling).
+  const existingById = new Map<string, cg.PieceNode>();
   let child = el.firstChild as cg.PieceNode | null;
   while (child) {
     const next = child.nextSibling as cg.PieceNode | null;
-    const idx = child.dataset['premoveStage'];
-    if (idx !== undefined) existingByStage.set(Number(idx), child);
+    const id = child.dataset['premoveId'];
+    if (id !== undefined) existingById.set(id, child);
     child = next;
   }
 
   // Always clear the source-hide class from authoritative piece nodes, then
-  // re-apply for any source that the virtual map has relocated. This is
-  // important: rerouting a stage must restore the prior source visibility.
+  // re-apply for any source (or capture target) the virtual map affects.
+  // This is important: rerouting a stage must restore the prior visibility.
   clearSourceHides(state.dom.elements.board);
 
-  const renderedStages = new Set<number>();
+  const renderedIds = new Set<string>();
 
   for (const stage of stages) {
-    // Hide the authoritative source square: the piece is virtually gone from
-    // there regardless of whether this particular stage is a resting place.
-    hideSource(state.dom.elements.board, stage.orig);
+    for (const key of stage.hidden) hideSource(state.dom.elements.board, key);
 
-    // A waypoint stage that a later item continues from is never drawn: the
-    // chain's final stage draws the piece for all of them.
-    if (stage.superseded) continue;
+    for (const placement of stage.placements) {
+      const id = `${stage.stage}:${placement.key}`;
+      renderedIds.add(id);
+      const existing = existingById.get(id);
+      // The *primary* piece of a stage — the one at the queue item's own
+      // `dest` — is what stageAt()/drag.ts grab a drag from. If it's the one
+      // currently being dragged, processDrag() owns its position every
+      // frame, so leave it untouched. A castling rook is never primary and
+      // is always safe to reconcile normally.
+      const isPrimary = placement.key === stage.dest;
 
-    renderedStages.add(stage.stage);
-    const isBeingDragged = dragStage === stage.stage;
-    const existing = existingByStage.get(stage.stage);
+      if (existing && isPrimary && dragStage === stage.stage) continue;
 
-    if (existing && isBeingDragged) {
-      // Owned by an in-progress drag; processDrag() is translating it every
-      // frame, so leave its position, key and classes exactly as they are.
-      continue;
+      const node =
+        existing ??
+        (() => {
+          const created = createEl('piece') as cg.PieceNode;
+          created.dataset['premoveStage'] = String(stage.stage);
+          created.dataset['premoveId'] = id;
+          el.appendChild(created);
+          return created;
+        })();
+
+      node.cgPiece = `${placement.piece.color} ${placement.piece.role}`;
+      node.cgKey = placement.key;
+      node.dataset['premoveOrig'] = stage.orig;
+      node.dataset['premoveDest'] = stage.dest;
+      node.className = `piece ${placement.piece.color} ${placement.piece.role} premove-piece premove-stage-${Math.min(
+        stage.stage + 1,
+        8,
+      )}`;
+      translate(node, posToTranslate(key2pos(placement.key), asWhite));
     }
-
-    const node =
-      existing ??
-      (() => {
-        const created = createEl('piece') as cg.PieceNode;
-        created.dataset['premoveStage'] = String(stage.stage);
-        el.appendChild(created);
-        return created;
-      })();
-
-    node.cgPiece = `${stage.piece.color} ${stage.piece.role}`;
-    node.cgKey = stage.dest;
-    node.dataset['premoveOrig'] = stage.orig;
-    node.dataset['premoveDest'] = stage.dest;
-    node.className = `piece ${stage.piece.color} ${stage.piece.role} premove-piece premove-stage-${Math.min(
-      stage.stage + 1,
-      8,
-    )}`;
-    translate(node, posToTranslate(key2pos(stage.dest), asWhite));
   }
 
-  // Remove nodes for stages that no longer exist, were rerouted away, or
-  // became waypoints superseded by a further hop.
-  for (const [stageIdx, node] of existingByStage) {
-    if (!renderedStages.has(stageIdx)) el.removeChild(node);
+  // Remove nodes for placements that no longer exist, were rerouted away, or
+  // became superseded by a further hop.
+  for (const [id, node] of existingById) {
+    if (!renderedIds.has(id)) el.removeChild(node);
   }
 }
 
@@ -176,19 +209,22 @@ export function renderResized(state: State): void {
     posToTranslate = posToTranslateFromBounds(state.dom.bounds());
   // Skip the node owned by an in-progress drag here too, for the same reason
   // as in render(): a resize firing mid-drag must not snap the dragged piece
-  // back to its resting square out from under the cursor.
+  // back to its resting square out from under the cursor. Only the primary
+  // placement of a stage (key === its own recorded dest) is ever draggable.
   const dragStage = state.draggable.current?.premoveStage;
   let node = el.firstChild as cg.PieceNode | null;
   while (node) {
-    const idx = node.dataset['premoveStage'];
-    const isBeingDragged = idx !== undefined && Number(idx) === dragStage;
+    const stageIdx = node.dataset['premoveStage'];
+    const isPrimary = node.dataset['premoveDest'] === node.cgKey;
+    const isBeingDragged = isPrimary && stageIdx !== undefined && Number(stageIdx) === dragStage;
     if (!isBeingDragged) translate(node, posToTranslate(key2pos(node.cgKey), asWhite));
     node = node.nextSibling as cg.PieceNode | null;
   }
 }
 
 /**
- * Look up which queue stage (if any) currently places a virtual piece at `key`.
+ * Look up which queue stage (if any) currently places its *primary* piece at
+ * `key` (a castling rook's square never matches here — see VirtualStage.dest).
  * Used by the drag handler so drags can start from a virtual destination and
  * re-route the corresponding queue item.
  */

--- a/src/premovePieces.ts
+++ b/src/premovePieces.ts
@@ -1,0 +1,216 @@
+import { whitePov } from './board.js';
+import { applyMoveToPieces } from './premove.js';
+import { type State } from './state.js';
+import type * as cg from './types.js';
+import { createEl, key2pos, posToTranslate as posToTranslateFromBounds, translate } from './util.js';
+
+type VirtualStage = {
+  stage: number;
+  orig: cg.Key;
+  dest: cg.Key;
+  piece: cg.Piece;
+  capturedAtDest: cg.Piece | undefined;
+  // True when a *later, successfully-computed* stage continues the move from
+  // this stage's `dest` — i.e. the same piece keeps advancing further down
+  // the chain. Such a stage is a transient waypoint on the hypothetical
+  // board, not a resting square, and must never get its own piece node: only
+  // the final square of a same-piece chain should ever show a piece. Without
+  // this, a piece re-premoved two or three times in a row (e.g. a bishop
+  // queued d2-c3, then c3-b4) renders once per hop instead of once at its
+  // actual final square.
+  superseded: boolean;
+};
+
+// Diff between authoritative `state.pieces` and the virtual map. The virtual
+// layer draws the moved piece at its destination, hides the source piece, and
+// shows the captured piece (if any) fading on the destination — same visual
+// contract as a real move. We compute one stage per queued item so the renderer
+// can tag each with a stage class (for stage-aware re-queueing on drag).
+function computeStages(state: State): VirtualStage[] {
+  if (!state.premovable.multiple || !state.premovable.queue.length) return [];
+  const queue = state.premovable.queue;
+  const raw: Omit<VirtualStage, 'superseded'>[] = [];
+  let live: cg.Pieces = state.pieces;
+  for (let i = 0; i < queue.length; i++) {
+    const item = queue[i];
+    const piece = live.get(item.orig);
+    if (!piece) break;
+    const destPiece = live.get(item.dest);
+    const captured = destPiece && destPiece.color !== piece.color ? destPiece : undefined;
+    raw.push({ stage: i, orig: item.orig, dest: item.dest, piece, capturedAtDest: captured });
+    live = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
+  }
+  // Superseded-ness is resolved against `raw` (the stages we actually
+  // validated above), never against the untouched tail of `queue`: an item
+  // sitting after a broken link in the chain was never reached by the loop
+  // above, so it must not be allowed to suppress an earlier, real resting
+  // square just because its `orig` happens to match that square's `dest`.
+  return raw.map((stage, i) => ({
+    ...stage,
+    superseded: raw.slice(i + 1).some(later => later.orig === stage.dest),
+  }));
+}
+
+/**
+ * Render the virtual premove pieces layer. Walks the queue stage-by-stage and
+ * adds piece nodes for the moved piece at its current destination. Sets a
+ * `.premove-piece` class plus a stage-ordinal class for each node. The CSS
+ * hides the corresponding authoritative source node visually.
+ *
+ * Two things this reconciles carefully, rather than doing a naive "wipe and
+ * rebuild" every call:
+ *
+ *  - A chain that re-premoves the *same* piece several times (e.g. a bishop
+ *    queued d2-c3, then c3-b4) produces one stage per hop, but only the last
+ *    hop is a real resting square — see `superseded` above. Waypoint stages
+ *    are skipped entirely so the piece is drawn exactly once, at its actual
+ *    final square.
+ *  - If the piece currently being dragged *is* one of these virtual nodes
+ *    (the user grabbed the piece from its premove destination to re-target
+ *    or extend the chain), that DOM node must not be destroyed and recreated
+ *    here. processDrag() (in drag.ts) holds a direct reference to it and
+ *    keeps translating it every animation frame; replacing it with a fresh
+ *    element would silently detach the one actually being dragged, so the
+ *    piece would stop following the cursor even though the drag is still
+ *    "live" underneath — which is why, before this fix, drag only ever
+ *    visibly worked for the very first premove.
+ *
+ * This renderer never mutates state.pieces. It also never reads back the FEN —
+ * callers (e.g. drag handler) can keep using `state.pieces` / `getFen()` as the
+ * authoritative source.
+ */
+export function render(state: State, el: HTMLElement): void {
+  const asWhite = whitePov(state),
+    posToTranslate = posToTranslateFromBounds(state.dom.bounds());
+  const stages = computeStages(state);
+  const dragStage = state.draggable.current?.premoveStage;
+
+  // Index existing virtual nodes by the stage they represent, so unaffected
+  // ones — in particular the one currently being dragged — can be left
+  // alone instead of being wiped and recreated.
+  const existingByStage = new Map<number, cg.PieceNode>();
+  let child = el.firstChild as cg.PieceNode | null;
+  while (child) {
+    const next = child.nextSibling as cg.PieceNode | null;
+    const idx = child.dataset['premoveStage'];
+    if (idx !== undefined) existingByStage.set(Number(idx), child);
+    child = next;
+  }
+
+  // Always clear the source-hide class from authoritative piece nodes, then
+  // re-apply for any source that the virtual map has relocated. This is
+  // important: rerouting a stage must restore the prior source visibility.
+  clearSourceHides(state.dom.elements.board);
+
+  const renderedStages = new Set<number>();
+
+  for (const stage of stages) {
+    // Hide the authoritative source square: the piece is virtually gone from
+    // there regardless of whether this particular stage is a resting place.
+    hideSource(state.dom.elements.board, stage.orig);
+
+    // A waypoint stage that a later item continues from is never drawn: the
+    // chain's final stage draws the piece for all of them.
+    if (stage.superseded) continue;
+
+    renderedStages.add(stage.stage);
+    const isBeingDragged = dragStage === stage.stage;
+    const existing = existingByStage.get(stage.stage);
+
+    if (existing && isBeingDragged) {
+      // Owned by an in-progress drag; processDrag() is translating it every
+      // frame, so leave its position, key and classes exactly as they are.
+      continue;
+    }
+
+    const node =
+      existing ??
+      (() => {
+        const created = createEl('piece') as cg.PieceNode;
+        created.dataset['premoveStage'] = String(stage.stage);
+        el.appendChild(created);
+        return created;
+      })();
+
+    node.cgPiece = `${stage.piece.color} ${stage.piece.role}`;
+    node.cgKey = stage.dest;
+    node.dataset['premoveOrig'] = stage.orig;
+    node.dataset['premoveDest'] = stage.dest;
+    node.className = `piece ${stage.piece.color} ${stage.piece.role} premove-piece premove-stage-${Math.min(
+      stage.stage + 1,
+      8,
+    )}`;
+    translate(node, posToTranslate(key2pos(stage.dest), asWhite));
+  }
+
+  // Remove nodes for stages that no longer exist, were rerouted away, or
+  // became waypoints superseded by a further hop.
+  for (const [stageIdx, node] of existingByStage) {
+    if (!renderedStages.has(stageIdx)) el.removeChild(node);
+  }
+}
+
+function clearSourceHides(board: HTMLElement): void {
+  let el = board.firstChild as cg.PieceNode | null;
+  while (el) {
+    if (el.classList.contains('premove-source')) el.classList.remove('premove-source');
+    el = el.nextSibling as cg.PieceNode | null;
+  }
+}
+
+function hideSource(board: HTMLElement, key: cg.Key): void {
+  let el = board.firstChild as cg.PieceNode | null;
+  while (el) {
+    if (el.cgKey === key && el.tagName === 'PIECE') {
+      el.classList.add('premove-source');
+      return;
+    }
+    el = el.nextSibling as cg.PieceNode | null;
+  }
+}
+
+export function renderResized(state: State): void {
+  const el = state.dom.elements.premovePieces;
+  if (!el) return;
+  const asWhite = whitePov(state),
+    posToTranslate = posToTranslateFromBounds(state.dom.bounds());
+  // Skip the node owned by an in-progress drag here too, for the same reason
+  // as in render(): a resize firing mid-drag must not snap the dragged piece
+  // back to its resting square out from under the cursor.
+  const dragStage = state.draggable.current?.premoveStage;
+  let node = el.firstChild as cg.PieceNode | null;
+  while (node) {
+    const idx = node.dataset['premoveStage'];
+    const isBeingDragged = idx !== undefined && Number(idx) === dragStage;
+    if (!isBeingDragged) translate(node, posToTranslate(key2pos(node.cgKey), asWhite));
+    node = node.nextSibling as cg.PieceNode | null;
+  }
+}
+
+/**
+ * Look up which queue stage (if any) currently places a virtual piece at `key`.
+ * Used by the drag handler so drags can start from a virtual destination and
+ * re-route the corresponding queue item.
+ */
+export function stageAt(state: State, key: cg.Key): number | undefined {
+  if (!state.premovable.multiple) return undefined;
+  const queue = state.premovable.queue;
+  if (!queue.length) return undefined;
+  // Find the stage whose `dest` is `key` and that stage is still valid (its
+  // origin exists on the resulting board). The destination is the only square
+  // a single premove can place a piece on, so this is unambiguous.
+  for (let i = 0; i < queue.length; i++) {
+    if (queue[i].dest === key) {
+      // Validate the stage: apply the queue up to and including it, ensure
+      // the piece lands on `key`.
+      let live: cg.Pieces = state.pieces;
+      for (let j = 0; j <= i; j++) {
+        const item = queue[j];
+        if (!live.has(item.orig)) return undefined;
+        live = applyMoveToPieces(live, item.orig, item.dest, { promotion: item.promotion });
+      }
+      if (live.get(key)) return i;
+    }
+  }
+  return undefined;
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,16 +1,21 @@
-import { type AnimCurrent, type AnimFadings, type AnimVector, type AnimVectors } from './anim.js';
-import { whitePov } from './board.js';
-import { type DragCurrent } from './drag.js';
-import { type State } from './state.js';
-import type * as cg from './types.js';
+import {
+  type AnimCurrent,
+  type AnimFadings,
+  type AnimVector,
+  type AnimVectors,
+} from "./anim.js";
+import { whitePov } from "./board.js";
+import { type DragCurrent } from "./drag.js";
+import { type State } from "./state.js";
+import type * as cg from "./types.js";
 import {
   createEl,
   key2pos,
   posToTranslate as posToTranslateFromBounds,
   setVisible,
   translate,
-} from './util.js';
-import * as util from './util.js';
+} from "./util.js";
+import * as util from "./util.js";
 
 type PieceName = string; // `$color $role`
 
@@ -50,14 +55,14 @@ export function render(s: State): void {
       elPieceName = el.cgPiece;
       // if piece not being dragged anymore, remove dragging style
       if (el.cgDragging && (!curDrag || curDrag.orig !== k)) {
-        el.classList.remove('dragging');
+        el.classList.remove("dragging");
         translate(el, posToTranslate(key2pos(k), asWhite));
         el.cgDragging = false;
       }
       // remove fading class if it still remains
       if (!fading && el.cgFading) {
         el.cgFading = false;
-        el.classList.remove('fading');
+        el.classList.remove("fading");
       }
       // there is now a piece at this dom key
       if (pieceAtKey) {
@@ -67,19 +72,24 @@ export function render(s: State): void {
           const pos = key2pos(k);
           pos[0] += anim[2];
           pos[1] += anim[3];
-          el.classList.add('anim');
+          el.classList.add("anim");
           translate(el, posToTranslate(pos, asWhite));
         } else if (el.cgAnimating) {
           el.cgAnimating = false;
-          el.classList.remove('anim');
+          el.classList.remove("anim");
           translate(el, posToTranslate(key2pos(k), asWhite));
-          if (s.addPieceZIndex) el.style.zIndex = posZIndex(key2pos(k), asWhite);
+          if (s.addPieceZIndex)
+            el.style.zIndex = posZIndex(key2pos(k), asWhite);
         }
         // same piece: flag as same
-        if (elPieceName === pieceNameOf(pieceAtKey) && (!fading || !el.cgFading)) samePieces.add(k);
+        if (
+          elPieceName === pieceNameOf(pieceAtKey) &&
+          (!fading || !el.cgFading)
+        )
+          samePieces.add(k);
         // different piece: flag as moved unless it is a fading piece
         else if (fading && elPieceName === pieceNameOf(fading)) {
-          el.classList.add('fading');
+          el.classList.add("fading");
           el.cgFading = true;
         } else appendValue(movedPieces, elPieceName, el);
       }
@@ -103,13 +113,13 @@ export function render(s: State): void {
     if (sAvail) {
       // repurpose an available square
       sAvail.cgKey = sk;
-      if (s.jsHover) sAvail.dataset['key'] = sk;
+      if (s.jsHover) sAvail.dataset["key"] = sk;
       translate(sAvail, translation);
       setVisible(sAvail, true);
     } else {
-      const squareNode = createEl('square', className) as cg.SquareNode;
+      const squareNode = createEl("square", className) as cg.SquareNode;
       squareNode.cgKey = sk;
-      if (s.jsHover) squareNode.dataset['key'] = sk;
+      if (s.jsHover) squareNode.dataset["key"] = sk;
       translate(squareNode, translation);
       boardEl.insertBefore(squareNode, boardEl.firstChild);
     }
@@ -132,14 +142,14 @@ export function render(s: State): void {
         // apply dom changes
         pMvd.cgKey = k;
         if (pMvd.cgFading) {
-          pMvd.classList.remove('fading');
+          pMvd.classList.remove("fading");
           pMvd.cgFading = false;
         }
         const pos = key2pos(k);
         if (s.addPieceZIndex) pMvd.style.zIndex = posZIndex(pos, asWhite);
         if (anim) {
           pMvd.cgAnimating = true;
-          pMvd.classList.add('anim');
+          pMvd.classList.add("anim");
           pos[0] += anim[2];
           pos[1] += anim[3];
         }
@@ -149,7 +159,7 @@ export function render(s: State): void {
       // assumes the new piece is not being dragged
       else {
         const pieceName = pieceNameOf(p),
-          pieceNode = createEl('piece', pieceName) as cg.PieceNode,
+          pieceNode = createEl("piece", pieceName) as cg.PieceNode,
           pos = key2pos(k);
 
         pieceNode.cgPiece = pieceName;
@@ -175,7 +185,10 @@ export function render(s: State): void {
 export function renderResized(s: State): void {
   const asWhite: boolean = whitePov(s),
     posToTranslate = posToTranslateFromBounds(s.dom.bounds());
-  let el = s.dom.elements.board.firstChild as cg.PieceNode | cg.SquareNode | undefined;
+  let el = s.dom.elements.board.firstChild as
+    | cg.PieceNode
+    | cg.SquareNode
+    | undefined;
   while (el) {
     if ((isPieceNode(el) && !el.cgAnimating) || isSquareNode(el)) {
       translate(el, posToTranslate(key2pos(el.cgKey), asWhite));
@@ -188,18 +201,22 @@ export function updateBounds(s: State): void {
   const bounds = s.dom.elements.wrap.getBoundingClientRect();
   const container = s.dom.elements.container;
   const ratio = bounds.height / bounds.width;
-  const width = (Math.floor((bounds.width * window.devicePixelRatio) / 8) * 8) / window.devicePixelRatio;
+  const width =
+    (Math.floor((bounds.width * window.devicePixelRatio) / 8) * 8) /
+    window.devicePixelRatio;
   const height = width * ratio;
-  container.style.width = width + 'px';
-  container.style.height = height + 'px';
+  container.style.width = width + "px";
+  container.style.height = height + "px";
   s.dom.bounds.clear();
 
-  s.addDimensionsCssVarsTo?.style.setProperty('---cg-width', width + 'px');
-  s.addDimensionsCssVarsTo?.style.setProperty('---cg-height', height + 'px');
+  s.addDimensionsCssVarsTo?.style.setProperty("---cg-width", width + "px");
+  s.addDimensionsCssVarsTo?.style.setProperty("---cg-height", height + "px");
 }
 
-const isPieceNode = (el: cg.PieceNode | cg.SquareNode): el is cg.PieceNode => el.tagName === 'PIECE';
-const isSquareNode = (el: cg.PieceNode | cg.SquareNode): el is cg.SquareNode => el.tagName === 'SQUARE';
+const isPieceNode = (el: cg.PieceNode | cg.SquareNode): el is cg.PieceNode =>
+  el.tagName === "PIECE";
+const isSquareNode = (el: cg.PieceNode | cg.SquareNode): el is cg.SquareNode =>
+  el.tagName === "SQUARE";
 
 function removeNodes(s: State, nodes: HTMLElement[]): void {
   for (const node of nodes) s.dom.elements.board.removeChild(node);
@@ -217,45 +234,67 @@ const pieceNameOf = (piece: cg.Piece): string => `${piece.color} ${piece.role}`;
 const normalizeLastMoveStandardRookCastle = (s: State, k: cg.Key): cg.Key =>
   !!s.lastMove?.[1] &&
   !s.pieces.has(s.lastMove[1]) &&
-  s.lastMove[0][0] === 'e' &&
-  ['h', 'a'].includes(s.lastMove[1][0]) &&
+  s.lastMove[0][0] === "e" &&
+  ["h", "a"].includes(s.lastMove[1][0]) &&
   s.lastMove[0][1] === s.lastMove[1][1] &&
-  util.squaresBetween(...key2pos(s.lastMove[0]), ...key2pos(s.lastMove[1])).some(sq => s.pieces.has(sq))
-    ? (((k > s.lastMove[0] ? 'g' : 'c') + k[1]) as cg.Key)
+  util
+    .squaresBetween(...key2pos(s.lastMove[0]), ...key2pos(s.lastMove[1]))
+    .some((sq) => s.pieces.has(sq))
+    ? (((k > s.lastMove[0] ? "g" : "c") + k[1]) as cg.Key)
     : k;
 
 function computeSquareClasses(s: State): cg.SquareClasses {
   const squares: cg.SquareClasses = new Map();
   if (s.lastMove && s.highlight.lastMove)
     for (const [i, k] of s.lastMove.entries())
-      addSquare(squares, i === 1 ? normalizeLastMoveStandardRookCastle(s, k) : k, 'last-move');
-  if (s.check && s.highlight.check) addSquare(squares, s.check, 'check');
+      addSquare(
+        squares,
+        i === 1 ? normalizeLastMoveStandardRookCastle(s, k) : k,
+        "last-move",
+      );
+  if (s.check && s.highlight.check) addSquare(squares, s.check, "check");
   if (s.selected) {
-    addSquare(squares, s.selected, 'selected');
+    addSquare(squares, s.selected, "selected");
     if (s.movable.showDests) {
       for (const k of s.movable.dests?.get(s.selected) ?? [])
-        addSquare(squares, k, 'move-dest' + (s.pieces.has(k) ? ' oc' : ''));
-      for (const k of s.premovable.customDests?.get(s.selected) ?? s.premovable.dests ?? [])
-        addSquare(squares, k, 'premove-dest' + (s.pieces.has(k) ? ' oc' : ''));
+        addSquare(squares, k, "move-dest" + (s.pieces.has(k) ? " oc" : ""));
+      for (const k of s.premovable.customDests?.get(s.selected) ??
+        s.premovable.dests ??
+        [])
+        addSquare(squares, k, "premove-dest" + (s.pieces.has(k) ? " oc" : ""));
     }
   }
   if (s.premovable.multiple && s.premovable.queue.length) {
     // Each queued premove highlights both its origin and destination squares,
     // using an ordinal class so consumers can give earlier/later moves a
     // distinct color ramp via CSS.
+    type Role = "start" | "via" | "end";
+    const marks = new Map<cg.Key, { n: number; role: Role }>();
     s.premovable.queue.forEach((item, i) => {
-      const klass = `premove-queue-${Math.min(i + 1, 8)}`;
-      addSquare(squares, item.orig, klass);
-      addSquare(squares, item.dest, klass);
+      const n = Math.min(i + 1, 8);
+      const prev = marks.get(item.orig);
+      // اگر قبلاً مهره‌ای از صف به این خونه رسیده و حالا از آن می‌رود → waypoint
+      // (شماره‌ی همان ورود را نگه می‌داریم)؛ وگرنه شروعِ یک زنجیره است
+      marks.set(
+        item.orig,
+        prev && prev.role !== "start"
+          ? { n: prev.n, role: "via" }
+          : { n, role: "start" },
+      );
+      marks.set(item.dest, { n, role: "end" });
     });
+    for (const [k, m] of marks)
+      addSquare(squares, k, `premove-queue-${m.n} premove-queue-${m.role}`);
   } else {
     const premove = s.premovable.current;
-    if (premove) for (const k of premove) addSquare(squares, k, 'current-premove');
-    else if (s.predroppable.current) addSquare(squares, s.predroppable.current.key, 'current-premove');
+    if (premove)
+      for (const k of premove) addSquare(squares, k, "current-premove");
+    else if (s.predroppable.current)
+      addSquare(squares, s.predroppable.current.key, "current-premove");
   }
 
   const o = s.exploding;
-  if (o) for (const k of o.keys) addSquare(squares, k, 'exploding' + o.stage);
+  if (o) for (const k of o.keys) addSquare(squares, k, "exploding" + o.stage);
 
   if (s.highlight.custom) {
     s.highlight.custom.forEach((v: string, k: cg.Key) => {
@@ -266,7 +305,11 @@ function computeSquareClasses(s: State): cg.SquareClasses {
   return squares;
 }
 
-function addSquare(squares: cg.SquareClasses, key: cg.Key, klass: string): void {
+function addSquare(
+  squares: cg.SquareClasses,
+  key: cg.Key,
+  klass: string,
+): void {
   const classes = squares.get(key);
   if (classes) squares.set(key, `${classes} ${klass}`);
   else squares.set(key, klass);

--- a/src/render.ts
+++ b/src/render.ts
@@ -239,9 +239,20 @@ function computeSquareClasses(s: State): cg.SquareClasses {
         addSquare(squares, k, 'premove-dest' + (s.pieces.has(k) ? ' oc' : ''));
     }
   }
-  const premove = s.premovable.current;
-  if (premove) for (const k of premove) addSquare(squares, k, 'current-premove');
-  else if (s.predroppable.current) addSquare(squares, s.predroppable.current.key, 'current-premove');
+  if (s.premovable.multiple && s.premovable.queue.length) {
+    // Each queued premove highlights both its origin and destination squares,
+    // using an ordinal class so consumers can give earlier/later moves a
+    // distinct color ramp via CSS.
+    s.premovable.queue.forEach((item, i) => {
+      const klass = `premove-queue-${Math.min(i + 1, 8)}`;
+      addSquare(squares, item.orig, klass);
+      addSquare(squares, item.dest, klass);
+    });
+  } else {
+    const premove = s.premovable.current;
+    if (premove) for (const k of premove) addSquare(squares, k, 'current-premove');
+    else if (s.predroppable.current) addSquare(squares, s.predroppable.current.key, 'current-premove');
+  }
 
   const o = s.exploding;
   if (o) for (const k of o.keys) addSquare(squares, k, 'exploding' + o.stage);

--- a/src/state.ts
+++ b/src/state.ts
@@ -54,13 +54,13 @@ export interface HeadlessState {
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
     current?: cg.KeyPair; // keys of the current saved premove ["e2" "e4"]
     multiple: boolean; // allow a queue of several premoves (chess.com-style chain)
-    maxQueueLength: number; // maximum number of premoves that can be queued
+    maxQueueLength: number; // maximum number of premoves that can be queued (>= 1)
     queue: cg.Premove[]; // the queued premoves, applied in order
     additionalPremoveRequirements: cg.Mobility;
     events: {
       set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
       unset?: () => void; // called after the premove has been unset
-      queueSet?: (queue: cg.Premove[]) => void; // called after the queue changes
+      queueSet?: (queue: cg.Premove[]) => void; // called after the queue changes; receives an immutable shallow copy
       queueUnset?: () => void; // called after the queue is emptied
     };
   };

--- a/src/state.ts
+++ b/src/state.ts
@@ -53,10 +53,15 @@ export interface HeadlessState {
     dests?: cg.Key[]; // premove destinations for the current selection
     customDests?: cg.Dests; // use custom valid premoves. {"a2" ["a3" "a4"] "b1" ["a3" "c3"]}
     current?: cg.KeyPair; // keys of the current saved premove ["e2" "e4"]
+    multiple: boolean; // allow a queue of several premoves (chess.com-style chain)
+    maxQueueLength: number; // maximum number of premoves that can be queued
+    queue: cg.Premove[]; // the queued premoves, applied in order
     additionalPremoveRequirements: cg.Mobility;
     events: {
       set?: (orig: cg.Key, dest: cg.Key, metadata?: cg.SetPremoveMetadata) => void; // called after the premove has been set
       unset?: () => void; // called after the premove has been unset
+      queueSet?: (queue: cg.Premove[]) => void; // called after the queue changes
+      queueUnset?: () => void; // called after the queue is emptied
     };
   };
   predroppable: {
@@ -147,6 +152,9 @@ export function defaults(): HeadlessState {
       enabled: true,
       showDests: true,
       castle: true,
+      multiple: false,
+      maxQueueLength: 5,
+      queue: [],
       additionalPremoveRequirements: _ => true,
       events: {},
     },
@@ -178,6 +186,7 @@ export function defaults(): HeadlessState {
       visible: true, // can view
       defaultSnapToValidMove: true,
       eraseOnMovablePieceClick: true,
+      knightMoveBend: false,
       shapes: [],
       autoShapes: [],
       brushes: {

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -308,6 +308,7 @@ function renderArrow(
       return setAttributes(createElement('path'), {
         d: bentArrowPath(s, from, to, m),
         stroke,
+        fill: 'none',
         'stroke-width': width,
         'stroke-linecap': 'round',
         'stroke-linejoin': 'round',

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -72,14 +72,30 @@ export function renderSvg(state: State, els: cg.Elements): void {
       shape: s,
       current: false,
       pendingErase: isPendingErase,
-      hash: shapeHash(s, isShort(s.dest, dests), false, bounds, isPendingErase, angleCount(s.dest, dests)),
+      hash: shapeHash(
+        s,
+        isShort(s.dest, dests),
+        false,
+        bounds,
+        isPendingErase,
+        angleCount(s.dest, dests),
+        shouldBend(s, d.knightMoveBend),
+      ),
     });
   }
   if (cur && pendingEraseIdx === -1)
     shapes.push({
       shape: cur,
       current: true,
-      hash: shapeHash(cur, isShort(cur.dest, dests), true, bounds, false, angleCount(cur.dest, dests)),
+      hash: shapeHash(
+        cur,
+        isShort(cur.dest, dests),
+        true,
+        bounds,
+        false,
+        angleCount(cur.dest, dests),
+        shouldBend(cur, d.knightMoveBend),
+      ),
       pendingErase: false,
     });
 
@@ -158,6 +174,7 @@ function shapeHash(
   bounds: DOMRectReadOnly,
   pendingErase: boolean,
   angleCountOfDest: number,
+  bend: boolean,
 ): Hash {
   // a shape and an overlay svg share a lifetime and have the same cgHash attribute
   return [
@@ -170,6 +187,7 @@ function shapeHash(
     dest,
     brush,
     shorten && '-',
+    bend && 'knight-bend',
     piece && pieceHash(piece),
     modifiers && modifiersHash(modifiers),
     customSvg && `custom-${textHash(customSvg.html)},${customSvg.center?.[0] ?? 'o'}`,
@@ -179,6 +197,19 @@ function shapeHash(
     .filter(Boolean)
     .join(',');
 }
+
+// A "knight bend" only applies to arrows whose origin and destination squares are
+// exactly a knight's move apart. The long leg (2 squares) is bent at a right angle.
+export const isKnightMove = (orig: cg.Key, dest: cg.Key): boolean => {
+  const a = key2pos(orig),
+    b = key2pos(dest);
+  const df = Math.abs(a[0] - b[0]),
+    dr = Math.abs(a[1] - b[1]);
+  return (df === 1 && dr === 2) || (df === 2 && dr === 1);
+};
+
+const shouldBend = (s: DrawShape, knightMoveBend: boolean): boolean =>
+  knightMoveBend && !!s.dest && s.orig !== s.dest && isKnightMove(s.orig, s.dest);
 
 const pieceHash = (piece: DrawShapePiece): Hash =>
   [piece.color, piece.role, piece.scale].filter(Boolean).join(',');
@@ -212,7 +243,9 @@ function renderShape(
     svgs.push({ el });
 
     if (from[0] !== to[0] || from[1] !== to[1])
-      el.appendChild(renderArrow(shape, brush, from, to, current, isShort(shape.dest, dests), pendingErase));
+      el.appendChild(
+        renderArrow(shape, brush, state, from, to, current, isShort(shape.dest, dests), pendingErase),
+      );
     else el.appendChild(renderCircle(brushes[shape.brush!], from, current, bounds, pendingErase));
   }
   if (shape.label) {
@@ -255,26 +288,44 @@ function renderCircle(
 function renderArrow(
   s: DrawShape,
   brush: DrawBrush,
+  state: State,
   from: cg.NumberPair,
   to: cg.NumberPair,
   current: boolean,
   shorten: boolean,
   pendingErase: boolean,
 ): SVGElement {
+  const bend = shouldBend(s, state.drawable.knightMoveBend);
+
   function renderLine(isHilite: boolean) {
     const m = arrowMargin(shorten && !current),
-      dx = to[0] - from[0],
+      hilite = hiliteOf(s),
+      stroke = isHilite ? hilite.color : brush.color,
+      width = lineWidth(brush, current) * (isHilite ? 1.14 : 1),
+      marker = `url(#arrowhead-${isHilite ? hilite.key : brush.key})`,
+      opacityVal = s.modifiers?.hilite && !pendingErase ? 1 : opacity(brush, current, pendingErase);
+    if (bend) {
+      return setAttributes(createElement('path'), {
+        d: bentArrowPath(s, from, to, m),
+        stroke,
+        'stroke-width': width,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+        'marker-end': marker,
+        opacity: opacityVal,
+      });
+    }
+    const dx = to[0] - from[0],
       dy = to[1] - from[1],
       angle = Math.atan2(dy, dx),
       xo = Math.cos(angle) * m,
       yo = Math.sin(angle) * m;
-    const hilite = hiliteOf(s);
     return setAttributes(createElement('line'), {
-      stroke: isHilite ? hilite.color : brush.color,
-      'stroke-width': lineWidth(brush, current) * (isHilite ? 1.14 : 1),
+      stroke,
+      'stroke-width': width,
       'stroke-linecap': 'round',
-      'marker-end': `url(#arrowhead-${isHilite ? hilite.key : brush.key})`,
-      opacity: s.modifiers?.hilite && !pendingErase ? 1 : opacity(brush, current, pendingErase),
+      'marker-end': marker,
+      opacity: opacityVal,
       x1: from[0],
       y1: from[1],
       x2: to[0] - xo,
@@ -290,6 +341,23 @@ function renderArrow(
   g.appendChild(blurred);
   g.appendChild(renderLine(false));
   return g;
+}
+
+// Builds the SVG path for a knight-move arrow bent at a right angle:
+// origin -> pivot (the long, 2-square leg) -> destination (the short, 1-square leg).
+// The long leg is the axis whose file/rank delta is 2, chosen from the board keys
+// so non-square (3D) boards are handled correctly. The final leg is shortened by
+// the arrow margin so the arrowhead is not overlapped.
+export function bentArrowPath(s: DrawShape, from: cg.NumberPair, to: cg.NumberPair, m: number): string {
+  const a = key2pos(s.orig),
+    b = key2pos(s.dest!),
+    longIsFile = Math.abs(a[0] - b[0]) === 2,
+    pivot: cg.NumberPair = longIsFile ? [to[0], from[1]] : [from[0], to[1]];
+  const ldx = to[0] - pivot[0],
+    ldy = to[1] - pivot[1],
+    len = Math.hypot(ldx, ldy),
+    end: cg.NumberPair = len === 0 ? to : [to[0] - (ldx / len) * m, to[1] - (ldy / len) * m];
+  return `M ${from[0]},${from[1]} L ${pivot[0]},${pivot[1]} L ${end[0]},${end[1]}`;
 }
 
 function renderMarker(brush: DrawBrush): SVGElement {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,12 @@ export type PiecesDiff = Map<Key, Piece | undefined>;
 
 export type KeyPair = [Key, Key];
 
+// a single item of the multi-premove queue (chess.com-style chain)
+export interface Premove {
+  orig: Key;
+  dest: Key;
+}
+
 export type NumberPair = [number, number];
 
 export type NumberQuad = [number, number, number, number];

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,14 @@ export type KeyPair = [Key, Key];
 export interface Premove {
   orig: Key;
   dest: Key;
+  role?: Role; // optional piece role (for promotion validation / rendering)
+  promotion?: Role; // optional promotion target (e.g. 'queen')
 }
+
+// purely derived: authoritative pieces with all queued premoves applied in order.
+// used for rendering the virtual layer and for computing subsequent destinations,
+// without ever mutating state.pieces.
+export type PremovePieces = Pieces;
 
 export type NumberPair = [number, number];
 
@@ -52,6 +59,7 @@ export interface Elements {
   shapesBelow?: SVGElement;
   customBelow?: SVGElement;
   autoPieces?: HTMLElement;
+  premovePieces?: HTMLElement;
 }
 export interface Dom {
   elements: Elements;
@@ -72,6 +80,7 @@ export interface MoveMetadata {
   holdTime?: number;
   captured?: Piece;
   predrop?: boolean;
+  promotion?: Role;
 }
 export interface SetPremoveMetadata {
   ctrlKey?: boolean;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -87,7 +87,25 @@ export function renderWrap(element: HTMLElement, s: HeadlessState): Elements {
     container.appendChild(ghost);
   }
 
-  return { board, container, wrap: element, ghost, shapes, shapesBelow, custom, customBelow, autoPieces };
+  // Virtual premove pieces layer: dedicated DOM sibling for the chess.com-style
+  // chain visualisation. Sits above normal pieces (so destination shows the
+  // moved piece) and below the drag ghost; pointer-events are disabled in CSS
+  // so it never interferes with hit testing.
+  const premovePieces = createEl('cg-premove-pieces');
+  container.appendChild(premovePieces);
+
+  return {
+    board,
+    container,
+    wrap: element,
+    ghost,
+    shapes,
+    shapesBelow,
+    custom,
+    customBelow,
+    autoPieces,
+    premovePieces,
+  };
 }
 
 function svgContainer(cls: string, isShapes: boolean) {

--- a/tests/dragPremove.test.ts
+++ b/tests/dragPremove.test.ts
@@ -1,0 +1,70 @@
+import { Chessground } from '../src/chessground';
+import type * as cg from '../src/types';
+
+type RfCb = FrameRequestCallback;
+
+const rect = { top: 0, left: 0, width: 400, height: 400, right: 400, bottom: 400 };
+const queue: RfCb[] = [];
+
+beforeAll(() => {
+  HTMLElement.prototype.getBoundingClientRect = () => rect as DOMRect;
+  (window as any).requestAnimationFrame = (cb: RfCb) => (queue.push(cb), queue.length);
+});
+
+function flushFrames(max = 50) {
+  let n = 0;
+  while (queue.length && n++ < max) {
+    const cb = queue.shift()!;
+    cb(0);
+  }
+}
+
+const centerOf = (key: cg.Key): cg.NumberPair => {
+  const [f, r] = [key.charCodeAt(0) - 97, key.charCodeAt(1) - 49];
+  return [((f + 0.5) * 400) / 8, ((7 - r + 0.5) * 400) / 8];
+};
+
+const makeBoard = (config: Record<string, any>) => {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  el.className = 'cg-wrap';
+  return Chessground(el as any, config);
+};
+
+const mdoc = (type: string, clientX: number, clientY: number) =>
+  new MouseEvent(type, {
+    clientX,
+    clientY,
+    bubbles: true,
+    cancelable: true,
+    isTrusted: true,
+  } as MouseEventInit);
+
+const drag = (orig: cg.Key, dest: cg.Key) => {
+  const [x0, y0] = centerOf(orig);
+  const [x1, y1] = centerOf(dest);
+  const b = document.querySelector('cg-board')!;
+  b.dispatchEvent(mdoc('mousedown', x0, y0));
+  document.dispatchEvent(mdoc('mousemove', x1, y1));
+  flushFrames();
+  document.dispatchEvent(mdoc('mouseup', x1, y1));
+  flushFrames();
+};
+
+const BOARD_FEN = '8/8/8/4k3/8/8/4P3/4K1N1 w - - 0 1';
+
+test('multi-premove via drag queues both moves', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  drag('e2', 'e4');
+  drag('g1', 'f3');
+  expect(ground.state.premovable.queue).toEqual([
+    { orig: 'e2', dest: 'e4' },
+    { orig: 'g1', dest: 'f3' },
+  ]);
+});

--- a/tests/interaction.test.ts
+++ b/tests/interaction.test.ts
@@ -72,7 +72,7 @@ test('single-premove mode holds exactly one premove (queue stays empty)', () => 
   expect(ground.state.premovable.queue).toEqual([]);
 });
 
-test('reconfiguring via set() preserves multiple/maxQueueLength and the queue', () => {
+test('reconfiguring via set() preserves multiple/maxQueueLength and the queue across FEN', () => {
   const ground = makeBoard({
     fen: BOARD_FEN,
     turnColor: 'black',
@@ -83,7 +83,9 @@ test('reconfiguring via set() preserves multiple/maxQueueLength and the queue', 
   click('e2');
   click('e4');
   expect(ground.state.premovable.queue.length).toBe(1);
-  // A typical host reconfigures on every turn, often without re-passing premovable.
+  // A host reconfiguring on every turn re-sends the FEN before it calls
+  // playPremove(). The chain must survive the FEN update so it can be
+  // validated against the new position at play time.
   ground.set({ fen: BOARD_FEN, turnColor: 'black', movable: { color: 'white', dests: new Map() } });
   expect(ground.state.premovable.multiple).toBe(true);
   expect(ground.state.premovable.maxQueueLength).toBe(4);

--- a/tests/interaction.test.ts
+++ b/tests/interaction.test.ts
@@ -1,0 +1,171 @@
+import { Chessground } from '../src/chessground';
+import type * as cg from '../src/types';
+
+const rect = { top: 0, left: 0, width: 400, height: 400, right: 400, bottom: 400 };
+beforeAll(() => {
+  HTMLElement.prototype.getBoundingClientRect = () => rect as DOMRect;
+});
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+const centerOf = (key: cg.Key): cg.NumberPair => {
+  const [f, r] = [key.charCodeAt(0) - 97, key.charCodeAt(1) - 49];
+  return [((f + 0.5) * 400) / 8, ((7 - r + 0.5) * 400) / 8];
+};
+
+const makeBoard = (config: Record<string, any>) => {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  el.className = 'cg-wrap';
+  return Chessground(el as any, config);
+};
+
+const mdoc = (type: string, clientX: number, clientY: number) =>
+  new MouseEvent(type, {
+    clientX,
+    clientY,
+    bubbles: true,
+    cancelable: true,
+    isTrusted: true,
+  } as MouseEventInit);
+
+const click = (key: cg.Key) => {
+  const [x, y] = centerOf(key);
+  const b = document.querySelector('cg-board')!;
+  b.dispatchEvent(mdoc('mousedown', x, y));
+  document.dispatchEvent(mdoc('mouseup', x, y));
+};
+
+const BOARD_FEN = '8/8/8/4k3/8/8/4P3/4K1N1 w - - 0 1'; // e2 pawn, g1 knight, e5 black king
+
+test('config-enabled multi-premove queue via click-click', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  expect(ground.state.premovable.queue).toEqual([
+    { orig: 'e2', dest: 'e4' },
+    { orig: 'g1', dest: 'f3' },
+  ]);
+});
+
+test('single-premove mode holds exactly one premove (queue stays empty)', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: false },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  // Single mode: one premove, no queue.
+  expect(ground.state.premovable.current).toEqual(['e2', 'e4']);
+  expect(ground.state.premovable.queue).toEqual([]);
+});
+
+test('reconfiguring via set() preserves multiple/maxQueueLength and the queue', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, maxQueueLength: 4 },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  expect(ground.state.premovable.queue.length).toBe(1);
+  // A typical host reconfigures on every turn, often without re-passing premovable.
+  ground.set({ fen: BOARD_FEN, turnColor: 'black', movable: { color: 'white', dests: new Map() } });
+  expect(ground.state.premovable.multiple).toBe(true);
+  expect(ground.state.premovable.maxQueueLength).toBe(4);
+  expect(ground.state.premovable.queue).toEqual([{ orig: 'e2', dest: 'e4' }]);
+});
+
+test('config flags land on state', () => {
+  const ground = makeBoard({
+    premovable: { multiple: true, maxQueueLength: 3 },
+    drawable: { enabled: true, knightMoveBend: true },
+  });
+  expect(ground.state.premovable.multiple).toBe(true);
+  expect(ground.state.premovable.maxQueueLength).toBe(3);
+  expect(ground.state.drawable.knightMoveBend).toBe(true);
+});
+
+test('knightMoveBend renders a two-segment bent path for a knight arrow', () => {
+  const ground = makeBoard({
+    drawable: {
+      enabled: true,
+      knightMoveBend: true,
+      autoShapes: [{ orig: 'g1', dest: 'f3', brush: 'green' }],
+    },
+  });
+  const g = ground.state.dom.elements.shapes!.querySelector('g')!;
+  const arrowPaths = Array.from(g.querySelectorAll('path')).filter(p => p.getAttribute('d')!.includes('L'));
+  expect(arrowPaths.length).toBe(1);
+  expect(
+    arrowPaths[0]
+      .getAttribute('d')!
+      .split(/\s/)
+      .filter(t => t === 'L').length,
+  ).toBe(2);
+});
+
+test('non-knight arrows stay straight even with knightMoveBend enabled', () => {
+  const ground = makeBoard({
+    drawable: {
+      enabled: true,
+      knightMoveBend: true,
+      autoShapes: [{ orig: 'e2', dest: 'e4', brush: 'green' }],
+    },
+  });
+  const g = ground.state.dom.elements.shapes!.querySelector('g')!;
+  expect(g.querySelectorAll('line').length).toBeGreaterThan(0);
+});
+
+test('multi mode: clicking empty/unrelated squares never clears the queue', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  expect(ground.state.premovable.queue.length).toBe(1);
+  // Clicking an empty square / a black king square must be a no-op for the queue.
+  click('a8');
+  click('e5');
+  expect(ground.state.premovable.queue).toEqual([{ orig: 'e2', dest: 'e4' }]);
+});
+
+test('multi mode renders ordinal queue highlight classes on the squares', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  const squares = Array.from(ground.state.dom.elements.board.querySelectorAll('square'));
+  const hasClass = (key: cg.Key, cls: string) =>
+    squares.some(sq => (sq as any).cgKey === key && sq.classList.contains(cls));
+  expect(hasClass('e2', 'premove-queue-1')).toBe(true);
+  expect(hasClass('e4', 'premove-queue-1')).toBe(true);
+  expect(hasClass('g1', 'premove-queue-2')).toBe(true);
+  expect(hasClass('f3', 'premove-queue-2')).toBe(true);
+});

--- a/tests/knightBend.test.ts
+++ b/tests/knightBend.test.ts
@@ -1,0 +1,58 @@
+import { bentArrowPath, isKnightMove } from '../src/svg';
+import type * as cg from '../src/types';
+
+// Square board (width = height), white orientation, so pos2user reduces to
+// x = file - 3.5, y = 3.5 - rank. These match the coordinates svg.ts computes.
+const centerOf = (key: cg.Key): cg.NumberPair => {
+  const [file, rank] = [key.charCodeAt(0) - 97, key.charCodeAt(1) - 49];
+  return [file - 3.5, 3.5 - rank];
+};
+
+const pathPoints = (d: string): cg.NumberPair[] =>
+  d
+    .split(/\s+/)
+    .filter(t => t !== 'M' && t !== 'L')
+    .map(t => t.split(',').map(Number));
+
+test('isKnightMove only matches (1,2)/(2,1) deltas', () => {
+  expect(isKnightMove('g1', 'e2')).toBe(true);
+  expect(isKnightMove('c6', 'e5')).toBe(true);
+  expect(isKnightMove('e2', 'e4')).toBe(false); // same file pawn double
+  expect(isKnightMove('e2', 'e5')).toBe(false); // straight three
+  expect(isKnightMove('e2', 'e2')).toBe(false); // no move
+});
+
+test('knight bend pivots on the long (2-square) leg and ends on the destination', () => {
+  // g1 -> e2: 2 files, 1 rank -> long leg runs along the file.
+  const from = centerOf('g1'),
+    to = centerOf('e2'),
+    d = bentArrowPath({ orig: 'g1', dest: 'e2' }, from, to, 0);
+  const [p1, p2, p3] = pathPoints(d);
+  expect(p1).toEqual([2.5, 3.5]);
+  expect(p2).toEqual([0.5, 3.5]); // pivot level with dest on file, orig on rank
+  expect(p3).toEqual([0.5, 2.5]);
+});
+
+test('knight bend handles the rank-long orientation', () => {
+  // e5 -> d7: 1 file, 2 ranks -> long leg runs along the rank.
+  const from = centerOf('e5'),
+    to = centerOf('d7'),
+    d = bentArrowPath({ orig: 'e5', dest: 'd7' }, from, to, 0);
+  const [p1, p2, p3] = pathPoints(d);
+  expect(p1).toEqual([0.5, -0.5]);
+  expect(p2).toEqual([0.5, -2.5]); // pivot level with orig on file, dest on rank
+  expect(p3).toEqual([-0.5, -2.5]);
+});
+
+test('knight bend shortens the final segment so the arrowhead is not overlapped', () => {
+  const from = centerOf('g1'),
+    to = centerOf('e2'),
+    m = 10 / 64,
+    d = bentArrowPath({ orig: 'g1', dest: 'e2' }, from, to, m);
+  const [, , p3] = pathPoints(d);
+  // The straight-line code shortens the arrow by moving its endpoint back along
+  // the incoming direction; here the last leg runs downward, so the endpoint
+  // moves back up toward the pivot (2.5 + m), leaving room for the arrowhead.
+  expect(p3[0]).toBeCloseTo(0.5);
+  expect(p3[1]).toBeCloseTo(2.5 + m);
+});

--- a/tests/premoveQueue.test.ts
+++ b/tests/premoveQueue.test.ts
@@ -1,0 +1,183 @@
+import * as board from '../src/board';
+import { applyMoveToPieces, premove } from '../src/premove';
+import { defaults, type HeadlessState } from '../src/state';
+import type * as cg from '../src/types';
+
+export const makeState = (pieces: cg.Pieces, turnColor: cg.Color, movableColor: cg.Color): HeadlessState => {
+  const state = defaults();
+  state.pieces = pieces;
+  state.turnColor = turnColor;
+  state.movable.color = movableColor;
+  state.premovable.multiple = true;
+  return state;
+};
+
+test('applyMoveToPieces relocates the piece and captures the destination', () => {
+  const pieces: cg.Pieces = new Map([
+    ['e3', { role: 'knight', color: 'white' }],
+    ['h6', { role: 'bishop', color: 'black' }],
+  ]);
+  const result = applyMoveToPieces(pieces, 'e3', 'h6');
+  expect(result.get('e3')).toBeUndefined();
+  expect(result.get('h6')).toEqual({ role: 'knight', color: 'white' });
+});
+
+test('premove queue computes destinations against a hypothetical board', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+
+  // On the real board c6 is empty, so no premove destinations.
+  expect(new Set(premove(state, 'c6'))).toEqual(new Set());
+
+  // On the hypothetical board the queued knight now sits on c6.
+  state.premovable.queue = [{ orig: 'b8', dest: 'c6' }];
+  const dests = new Set(premove(state, 'c6'));
+  expect(dests.has('e5')).toBe(true);
+  expect(dests.has('d4')).toBe(true);
+});
+
+test('queue items can chain by continuing to move the same piece', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+
+  expect(board.userMove(state, 'b8', 'c6')).toBe(true);
+  expect(state.premovable.queue).toEqual([{ orig: 'b8', dest: 'c6' }]);
+  // The second move starts from the knight's hypothetical destination.
+  expect(board.userMove(state, 'c6', 'e5')).toBe(true);
+  expect(state.premovable.queue).toEqual([
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'c6', dest: 'e5' },
+  ]);
+  expect(state.premovable.current).toEqual(['b8', 'c6']);
+});
+
+test('re-queueing an origin replaces that item and everything after it', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'c6', dest: 'e5' },
+  ];
+  // Re-queueing from c6 (an existing origin) truncates from there and replaces it.
+  expect(board.userMove(state, 'c6', 'a5')).toBe(true);
+  expect(state.premovable.queue).toEqual([
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'c6', dest: 'a5' },
+  ]);
+});
+
+test('queue respects maxQueueLength', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['a7', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.maxQueueLength = 2;
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'a7', dest: 'a6' },
+  ];
+  // The third move exceeds the cap and is ignored.
+  board.userMove(state, 'c6', 'e5');
+  expect(state.premovable.queue.length).toBe(2);
+});
+
+test('playPremove plays the front and keeps the rest of the queue', () => {
+  const pieces: cg.Pieces = new Map([
+    ['a7', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'black', 'black');
+  state.movable.free = false;
+  state.premovable.queue = [
+    { orig: 'a7', dest: 'a6' },
+    { orig: 'e8', dest: 'e7' },
+  ];
+  state.movable.dests = new Map([
+    ['a7', ['a6']],
+    ['e8', ['e7']],
+  ]);
+
+  expect(board.playPremove(state)).toBe(true);
+  expect(state.pieces.get('a6')).toEqual({ role: 'pawn', color: 'black' });
+  expect(state.pieces.has('a7')).toBe(false);
+  expect(state.turnColor).toBe('white');
+  // Only one move happens per turn; the second item stays queued.
+  expect(state.premovable.queue).toEqual([{ orig: 'e8', dest: 'e7' }]);
+  expect(state.premovable.current).toEqual(['e8', 'e7']);
+});
+
+test('cancelPremove pops the front and popLastPremove pops the back of the queue', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['a7', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'a7', dest: 'a6' },
+  ];
+  state.premovable.current = ['b8', 'c6'];
+
+  board.popLastPremove(state);
+  expect(state.premovable.queue).toEqual([{ orig: 'b8', dest: 'c6' }]);
+
+  board.cancelPremoveFront(state);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+});
+
+test('cancelPremoveQueue clears the whole queue', () => {
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['a7', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'a7', dest: 'a6' },
+  ];
+  state.premovable.current = ['b8', 'c6'];
+
+  board.unsetPremoveQueue(state);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+});
+
+test('playPremove clears the whole queue when the front becomes illegal', () => {
+  const pieces: cg.Pieces = new Map([
+    ['a7', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'black', 'black');
+  state.movable.free = false;
+  state.premovable.queue = [
+    { orig: 'a7', dest: 'a6' },
+    { orig: 'e8', dest: 'e7' },
+  ];
+  state.movable.dests = new Map([['a7', ['a5']]]);
+
+  expect(board.playPremove(state)).toBe(false);
+  expect(state.premovable.queue).toEqual([]);
+  expect(state.premovable.current).toBeUndefined();
+});

--- a/tests/premoveVirtual.test.ts
+++ b/tests/premoveVirtual.test.ts
@@ -1,0 +1,379 @@
+import { Chessground } from '../src/chessground';
+import * as board from '../src/board';
+import { configure } from '../src/config';
+import { applyMoveToPieces, fullPremovePieces } from '../src/premove';
+import { stageAt } from '../src/premovePieces';
+import { defaults, type HeadlessState } from '../src/state';
+import type * as cg from '../src/types';
+
+const rect = { top: 0, left: 0, width: 400, height: 400, right: 400, bottom: 400 };
+
+beforeAll(() => {
+  HTMLElement.prototype.getBoundingClientRect = () => rect as DOMRect;
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+const centerOf = (key: cg.Key): cg.NumberPair => {
+  const [f, r] = [key.charCodeAt(0) - 97, key.charCodeAt(1) - 49];
+  return [((f + 0.5) * 400) / 8, ((7 - r + 0.5) * 400) / 8];
+};
+
+const makeBoard = (config: Record<string, any>) => {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  el.className = 'cg-wrap';
+  return Chessground(el as any, config);
+};
+
+const mdoc = (type: string, clientX: number, clientY: number) =>
+  new MouseEvent(type, {
+    clientX,
+    clientY,
+    bubbles: true,
+    cancelable: true,
+    isTrusted: true,
+  } as MouseEventInit);
+
+const click = (key: cg.Key) => {
+  const [x, y] = centerOf(key);
+  const b = document.querySelector('cg-board')!;
+  b.dispatchEvent(mdoc('mousedown', x, y));
+  document.dispatchEvent(mdoc('mouseup', x, y));
+};
+
+const BOARD_FEN = '8/8/8/4k3/8/8/4P3/4K1N1 w - - 0 1';
+const makeState = (pieces: cg.Pieces, turnColor: cg.Color, movableColor: cg.Color): HeadlessState => {
+  const state = defaults();
+  state.pieces = pieces;
+  state.turnColor = turnColor;
+  state.movable.color = movableColor;
+  state.premovable.multiple = true;
+  return state;
+};
+
+test('applyMoveToPieces models castling rook relocation', () => {
+  const pieces: cg.Pieces = new Map([
+    ['e1', { role: 'king', color: 'white' }],
+    ['h1', { role: 'rook', color: 'white' }],
+    ['e8', { role: 'king', color: 'black' }],
+  ]);
+  const result = applyMoveToPieces(pieces, 'e1', 'g1');
+  expect(result.get('e1')).toBeUndefined();
+  expect(result.get('h1')).toBeUndefined();
+  expect(result.get('g1')).toEqual({ role: 'king', color: 'white' });
+  expect(result.get('f1')).toEqual({ role: 'rook', color: 'white' });
+});
+
+test('applyMoveToPieces models pawn promotion (defaults to queen)', () => {
+  const pieces: cg.Pieces = new Map([
+    ['a7', { role: 'pawn', color: 'white' }],
+    ['h8', { role: 'rook', color: 'black' }],
+  ]);
+  const result = applyMoveToPieces(pieces, 'a7', 'a8');
+  expect(result.get('a8')).toEqual({ role: 'queen', color: 'white', promoted: true });
+});
+
+test('applyMoveToPieces honors explicit promotion role', () => {
+  const pieces: cg.Pieces = new Map([
+    ['a7', { role: 'pawn', color: 'white' }],
+    ['h8', { role: 'rook', color: 'black' }],
+  ]);
+  const result = applyMoveToPieces(pieces, 'a7', 'a8', { promotion: 'knight' });
+  expect(result.get('a8')).toEqual({ role: 'knight', color: 'white', promoted: true });
+});
+
+test('applyMoveToPieces models en-passant capture', () => {
+  // White pawn on e5, black pawn on d5, white plays exd6 en passant.
+  const pieces: cg.Pieces = new Map([
+    ['e5', { role: 'pawn', color: 'white' }],
+    ['d5', { role: 'pawn', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+  ]);
+  const result = applyMoveToPieces(pieces, 'e5', 'd6');
+  expect(result.get('e5')).toBeUndefined();
+  expect(result.get('d5')).toBeUndefined();
+  expect(result.get('d6')).toEqual({ role: 'pawn', color: 'white' });
+});
+
+test('a queued item with no matching origin in the hypothetical board is a no-op', () => {
+  // First move relocates the b8 knight, so a follow-up "from b8" item has no
+  // origin in the resulting hypothetical board and must be silently skipped.
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'b8', dest: 'a6' }, // invalid follow-up: b8 is empty after stage 0
+  ];
+  const v = fullPremovePieces(state);
+  expect(v.get('c6')).toEqual({ role: 'knight', color: 'black' });
+  expect(v.has('a6')).toBe(false);
+});
+
+test('queue immutability: queueSet receives a copy, not the internal array', async () => {
+  const pieces: cg.Pieces = new Map([
+    ['e2', { role: 'pawn', color: 'white' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'black', 'white');
+  const seen: cg.Premove[][] = [];
+  state.premovable.events.queueSet = q => seen.push(q);
+  board.userMove(state, 'e2', 'e4');
+  // queueSet is invoked via setTimeout — flush microtasks/macrotasks.
+  await new Promise(r => setTimeout(r, 5));
+  expect(seen.length).toBe(1);
+  // Mutating the snapshot must not affect the internal queue.
+  seen[0].length = 0;
+  expect(state.premovable.queue).toEqual([{ orig: 'e2', dest: 'e4' }]);
+});
+
+test('maxQueueLength normalizes non-positive values to 1', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, maxQueueLength: 0 },
+    trustAllEvents: true,
+  });
+  expect(ground.state.premovable.maxQueueLength).toBe(1);
+});
+
+test('lowering maxQueueLength truncates the queue', () => {
+  const pieces: cg.Pieces = new Map([
+    ['e2', { role: 'pawn', color: 'white' }],
+    ['g1', { role: 'knight', color: 'white' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'black', 'white');
+  state.movable.free = false;
+  state.premovable.queue = [
+    { orig: 'e2', dest: 'e4' },
+    { orig: 'g1', dest: 'f3' },
+  ];
+  state.movable.dests = new Map();
+  // Reconfigure with a smaller cap.
+  state.movable.dests = undefined;
+  configure(state, { premovable: { maxQueueLength: 1 } });
+  expect(state.premovable.queue.length).toBe(1);
+  expect(state.premovable.queue[0]).toEqual({ orig: 'e2', dest: 'e4' });
+});
+
+test('switching from single to multiple (or vice versa) clears the queue', () => {
+  const pieces: cg.Pieces = new Map([
+    ['e2', { role: 'pawn', color: 'white' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'black', 'white');
+  state.premovable.multiple = false;
+  board.userMove(state, 'e2', 'e4');
+  expect(state.premovable.current).toEqual(['e2', 'e4']);
+  configure(state, { premovable: { multiple: true } });
+  expect(state.premovable.current).toBeUndefined();
+  expect(state.premovable.queue).toEqual([]);
+});
+
+test('Api.playPremove returns false when the queue is empty even if current is set', () => {
+  const pieces: cg.Pieces = new Map([
+    ['e2', { role: 'pawn', color: 'white' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const ground = makeBoard({
+    fen: '8/8/8/8/8/8/4P3/4K3 b - - 0 1',
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  // Stale `current` set manually but queue is empty.
+  ground.state.premovable.queue = [];
+  ground.state.premovable.current = ['e2', 'e4'];
+  expect(ground.playPremove()).toBe(false);
+});
+
+test('virtual layer renders the moved piece at the destination and hides the source', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  const layer = ground.state.dom.elements.premovePieces!;
+  const virtual = Array.from(layer.querySelectorAll('piece')) as cg.PieceNode[];
+  expect(virtual.length).toBe(2);
+  const keys = virtual.map(n => n.cgKey).sort();
+  expect(keys).toEqual(['e4', 'f3']);
+  // The authoritative source nodes (e2, g1) should be visually hidden.
+  const boardEl = ground.state.dom.elements.board;
+  const hidden = Array.from(boardEl.querySelectorAll('piece.premove-source')) as cg.PieceNode[];
+  const hiddenKeys = hidden.map(n => n.cgKey).sort();
+  expect(hiddenKeys).toEqual(['e2', 'g1']);
+});
+
+test('drag from a virtual destination retargets the owning queue stage, preserving its origin', async () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  // Queue two premoves via click-click.
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  // Drag the virtual knight on f3 onto g5. The knight's true origin is g1, so
+  // the stage that used to read g1→f3 is retargeted to g1→g5.
+  const [x0, y0] = centerOf('f3');
+  const [x1, y1] = centerOf('g5');
+  const b = document.querySelector('cg-board')!;
+  b.dispatchEvent(mdoc('mousedown', x0, y0));
+  document.dispatchEvent(mdoc('mousemove', x1, y1));
+  // Wait for the next animation frame used by processDrag.
+  await new Promise(r => requestAnimationFrame(() => r(null)));
+  document.dispatchEvent(mdoc('mouseup', x1, y1));
+  ground.state.dom.redrawNow();
+  // Stage 0 is preserved; stage 1 is retargeted to g1→g5.
+  expect(ground.state.premovable.queue).toEqual([
+    { orig: 'e2', dest: 'e4' },
+    { orig: 'g1', dest: 'g5' },
+  ]);
+  const layer = ground.state.dom.elements.premovePieces!;
+  const virtual = Array.from(layer.querySelectorAll('piece')) as cg.PieceNode[];
+  expect(virtual.map(n => n.cgKey).sort()).toEqual(['e4', 'g5']);
+  const boardEl = ground.state.dom.elements.board;
+  const hidden = Array.from(boardEl.querySelectorAll('piece.premove-source')) as cg.PieceNode[];
+  expect(hidden.map(n => n.cgKey).sort()).toEqual(['e2', 'g1']);
+  // Authoritative state.pieces and FEN remain untouched.
+  expect(ground.state.pieces.get('e4')).toBeUndefined();
+  expect(ground.state.pieces.get('g5')).toBeUndefined();
+  expect(ground.getFen()).toBe(BOARD_FEN.split(' ')[0]);
+});
+
+test('state.pieces and getFen() remain unchanged while premoves are queued', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  const fenBefore = ground.getFen();
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  expect(ground.state.pieces.get('e2')).toBeDefined();
+  expect(ground.state.pieces.get('e4')).toBeUndefined();
+  expect(ground.getFen()).toBe(fenBefore);
+});
+
+test('stageAt locates the queue index that owns a virtual destination', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  expect(stageAt(ground.state, 'e4')).toBe(0);
+  expect(stageAt(ground.state, 'f3')).toBe(1);
+  expect(stageAt(ground.state, 'e2')).toBeUndefined();
+});
+
+test('orientation flip moves virtual pieces correctly without mutating state', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  ground.toggleOrientation();
+  // Queue must survive the flip.
+  expect(ground.state.premovable.queue.length).toBe(2);
+  const layer = ground.state.dom.elements.premovePieces!;
+  const virtual = Array.from(layer.querySelectorAll('piece')) as cg.PieceNode[];
+  expect(virtual.map(n => n.cgKey).sort()).toEqual(['e4', 'f3']);
+});
+
+test('cancelPremoveQueue removes the virtual pieces and unhides sources', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  ground.cancelPremoveQueue();
+  ground.state.dom.redrawNow();
+  expect(ground.state.premovable.queue).toEqual([]);
+  const layer = ground.state.dom.elements.premovePieces!;
+  expect(layer.querySelectorAll('piece').length).toBe(0);
+  const hidden = Array.from(ground.state.dom.elements.board.querySelectorAll('piece.premove-source'));
+  expect(hidden.length).toBe(0);
+});
+
+test('setting a new FEN keeps the pending queue for validation at play time', () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  click('e2');
+  click('e4');
+  expect(ground.state.premovable.queue.length).toBe(1);
+  // The opponent's move arrives as a new FEN; the chain survives so the host
+  // can playPremove() (validation against movable.dests clears it if broken).
+  ground.set({ fen: BOARD_FEN });
+  expect(ground.state.premovable.queue).toEqual([{ orig: 'e2', dest: 'e4' }]);
+  expect(ground.state.premovable.current).toEqual(['e2', 'e4']);
+});
+
+test('fullPremovePieces on a broken chain returns the board at the break point', () => {
+  // A chain that depends on a captured origin should not silently apply later
+  // moves to the wrong board.
+  const pieces: cg.Pieces = new Map([
+    ['b8', { role: 'knight', color: 'black' }],
+    ['e8', { role: 'king', color: 'black' }],
+    ['e1', { role: 'king', color: 'white' }],
+  ]);
+  const state = makeState(pieces, 'white', 'black');
+  state.premovable.queue = [
+    { orig: 'b8', dest: 'c6' },
+    { orig: 'b8', dest: 'a6' }, // b8 is empty after the first hop
+  ];
+  const v = fullPremovePieces(state);
+  expect(v.get('c6')).toEqual({ role: 'knight', color: 'black' });
+  expect(v.has('a6')).toBe(false);
+  expect(v.has('b8')).toBe(false);
+});

--- a/tests/premoveVirtual.test.ts
+++ b/tests/premoveVirtual.test.ts
@@ -179,10 +179,6 @@ test('switching from single to multiple (or vice versa) clears the queue', () =>
 });
 
 test('Api.playPremove returns false when the queue is empty even if current is set', () => {
-  const pieces: cg.Pieces = new Map([
-    ['e2', { role: 'pawn', color: 'white' }],
-    ['e1', { role: 'king', color: 'white' }],
-  ]);
   const ground = makeBoard({
     fen: '8/8/8/8/8/8/4P3/4K3 b - - 0 1',
     turnColor: 'black',
@@ -221,7 +217,7 @@ test('virtual layer renders the moved piece at the destination and hides the sou
   expect(hiddenKeys).toEqual(['e2', 'g1']);
 });
 
-test('drag from a virtual destination retargets the owning queue stage, preserving its origin', async () => {
+test('drag from a virtual destination extends the chain from that square', async () => {
   const ground = makeBoard({
     fen: BOARD_FEN,
     turnColor: 'black',
@@ -235,8 +231,11 @@ test('drag from a virtual destination retargets the owning queue stage, preservi
   click('g1');
   click('f3');
   ground.state.dom.redrawNow();
-  // Drag the virtual knight on f3 onto g5. The knight's true origin is g1, so
-  // the stage that used to read g1→f3 is retargeted to g1→g5.
+  // Drag the virtual knight on f3 onto g5. f3 is not a queued origin yet, so
+  // this behaves exactly like clicking f3 then g5: the move is appended as a
+  // new hop (knight g1→f3, then f3→g5) rather than replacing the earlier
+  // stage. The intermediate square f3 is superseded visually — the knight is
+  // drawn once, at its final queued square (g5).
   const [x0, y0] = centerOf('f3');
   const [x1, y1] = centerOf('g5');
   const b = document.querySelector('cg-board')!;
@@ -246,11 +245,13 @@ test('drag from a virtual destination retargets the owning queue stage, preservi
   await new Promise(r => requestAnimationFrame(() => r(null)));
   document.dispatchEvent(mdoc('mouseup', x1, y1));
   ground.state.dom.redrawNow();
-  // Stage 0 is preserved; stage 1 is retargeted to g1→g5.
+  // Stages 0–1 are preserved; stage 2 continues the chain from f3.
   expect(ground.state.premovable.queue).toEqual([
     { orig: 'e2', dest: 'e4' },
-    { orig: 'g1', dest: 'g5' },
+    { orig: 'g1', dest: 'f3' },
+    { orig: 'f3', dest: 'g5' },
   ]);
+  expect(ground.state.premovable.current).toEqual(['e2', 'e4']);
   const layer = ground.state.dom.elements.premovePieces!;
   const virtual = Array.from(layer.querySelectorAll('piece')) as cg.PieceNode[];
   expect(virtual.map(n => n.cgKey).sort()).toEqual(['e4', 'g5']);
@@ -260,6 +261,48 @@ test('drag from a virtual destination retargets the owning queue stage, preservi
   // Authoritative state.pieces and FEN remain untouched.
   expect(ground.state.pieces.get('e4')).toBeUndefined();
   expect(ground.state.pieces.get('g5')).toBeUndefined();
+  expect(ground.getFen()).toBe(BOARD_FEN.split(' ')[0]);
+});
+
+test('drag from a queued origin retargets that stage and drops later hops', async () => {
+  const ground = makeBoard({
+    fen: BOARD_FEN,
+    turnColor: 'black',
+    movable: { color: 'white', dests: new Map() },
+    premovable: { enabled: true, multiple: true, showDests: true },
+    trustAllEvents: true,
+  });
+  // Queue two premoves via click-click.
+  click('e2');
+  click('e4');
+  click('g1');
+  click('f3');
+  ground.state.dom.redrawNow();
+  // Drag the knight from its real origin g1 onto h3. g1 is already used as an
+  // origin by stage 1, so re-queueing from it replaces that stage (and any
+  // hops queued after it) with g1→h3.
+  const [x0, y0] = centerOf('g1');
+  const [x1, y1] = centerOf('h3');
+  const b = document.querySelector('cg-board')!;
+  b.dispatchEvent(mdoc('mousedown', x0, y0));
+  document.dispatchEvent(mdoc('mousemove', x1, y1));
+  // Wait for the next animation frame used by processDrag.
+  await new Promise(r => requestAnimationFrame(() => r(null)));
+  document.dispatchEvent(mdoc('mouseup', x1, y1));
+  ground.state.dom.redrawNow();
+  // Stage 0 is preserved; stage 1 is retargeted to g1→h3.
+  expect(ground.state.premovable.queue).toEqual([
+    { orig: 'e2', dest: 'e4' },
+    { orig: 'g1', dest: 'h3' },
+  ]);
+  const layer = ground.state.dom.elements.premovePieces!;
+  const virtual = Array.from(layer.querySelectorAll('piece')) as cg.PieceNode[];
+  expect(virtual.map(n => n.cgKey).sort()).toEqual(['e4', 'h3']);
+  const boardEl = ground.state.dom.elements.board;
+  const hidden = Array.from(boardEl.querySelectorAll('piece.premove-source')) as cg.PieceNode[];
+  expect(hidden.map(n => n.cgKey).sort()).toEqual(['e2', 'g1']);
+  // Authoritative state.pieces and FEN remain untouched.
+  expect(ground.state.pieces.get('h3')).toBeUndefined();
   expect(ground.getFen()).toBe(BOARD_FEN.split(' ')[0]);
 });
 


### PR DESCRIPTION
Implements two opt-in features on top of the existing chessground behavior, without breaking any current consumer.

Feature 1 — Chess.com-style multi-premove queue (`premovable.multiple`, default `false`)
Queue a chain of premoves while it's still the opponent's turn, computed against a hypothetical board.

`src/types.ts` — new `Premove { orig; dest }`.
`src/state.ts` — `premovable.multiple`, `premovable.maxQueueLength` (default `5`), `premovable.queue`, `events.queueSet`/`queueUnset`; defaults keep old behavior.
`src/config.ts` — new public `premovable` options/events in `Config`.
`src/premove.ts` — `applyMoveToPieces()` and `premovePieces()` build the hypothetical board (items 1..N-1 applied); `premove()` computes destinations against it and truncates the queue when re-queueing an existing origin.
`src/board.ts` — `setPremove` appends to the queue when `multiple`; added `cancelPremoveFront`, `popLastPremove`, `unsetPremoveQueue`; `isPremovable` checks the hypothetical board; `playPremove` plays the front item for real (one move per turn) and clears the entire queue if it became illegal.
`src/api.ts` — `cancelPremove()` pops the front in multi mode; new `cancelPremoveQueue()` and `popLastPremove()`.
`src/render.ts` — ordinal square classes `premove-queue-N`.
`assets/chessground.base.css` — default CSS color ramp via `--premove-queue-color-1..8`.
Feature 2 — L-shaped (bent) knight-move arrows (`drawable.knightMoveBend`, default `false`)
`src/config.ts` / `src/draw.ts` / `src/state.ts` — `drawable.knightMoveBend` flag.
`src/svg.ts` — `isKnightMove()` and `bentArrowPath()`; `renderArrow` draws a two-segment right-angle polyline for exactly `(1,2)`/`(2,1)` deltas, with the arrowhead on the final leg, for both stored shapes and the live drag preview.
Tests & docs
`tests/premoveQueue.test.ts` (9) — hypothetical-board dests, same-piece chaining, re-queue truncation, maxQueueLength, front-play / illegal-front clearing, front/back pop, full clear.
`tests/knightBend.test.ts` (4) — `isKnightMove`, pivot points (file-long and rank-long), arrowhead-shortened final leg.
`docs/premove.md` + README link — full premove usage guide.
Verification
`tsc --sourceMap --declaration` → clean
`oxlint` → 0 warnings, 0 errors
`oxfmt --check` → clean
`vitest run` → 16/16 passing
Both features default off for pixel-for-pixel backward compatibility; no global behavior changes unless a host opts in.